### PR TITLE
Extends ComponentOptions with `ability` member

### DIFF
--- a/packages/casl-vue/index.d.ts
+++ b/packages/casl-vue/index.d.ts
@@ -9,3 +9,9 @@ declare module "vue/types/vue" {
     $can(action: string, subject: any, field?: string): boolean
   }
 }
+ 
+declare module "vue/types/options" {
+  interface ComponentOptions<V extends Vue> {
+    ability?: Ability;
+  }
+}


### PR DESCRIPTION
This fix a typescript error when following the tutorial:

Code:
```ts
import { abilitiesPlugin } from '@casl/vue'
import Vue from 'vue';
import ability from './ability'

new Vue({
  router,
  store,
  ability,
  render: (h) => h(App),
}).$mount('#app')
```

Error:
```
[ts]
Argument of type '{ router: VueRouter; store: Store<{}>; ability: Ability; render: (h: CreateElement) => VNode; }' is not assignable to parameter of type 'ComponentOptions<Vue, DefaultData<Vue>, DefaultMethods<Vue>, DefaultComputed, PropsDefinition<Rec...'.
  Object literal may only specify known properties, and 'ability' does not exist in type 'ComponentOptions<Vue, DefaultData<Vue>, DefaultMethods<Vue>, DefaultComputed, PropsDefinition<Rec...'.
```
