### PR TITLE
docs(aliases): clarifying addAlias arguments

### DIFF
--- a/docs/_posts/2017-07-20-define-abilities.md
+++ b/docs/_posts/2017-07-20-define-abilities.md
@@ -142,7 +142,7 @@ console.log(ability.rules)
 
 ## Define own aliases
 
-To define a new alias you can use `addAlias` method which accepts 2 arguments: alias name and one or few action names. For example, here we define `modify` alias to `update` and `delete`. While checking abilities, you can then use the action names `update` or `delete` to check for the `modify` ability defined in your rules.
+To define a new alias you can use `addAlias` method which accepts 2 arguments: the action name and one or few aliases for that action. For example, here we target `modify` as the action to which `update` and `delete` refer. Then while checking abilities, you can use the aliases `update` or `delete` to check against the `modify` ability defined in your rules.
 
 ```js
 import { Ability, AbilityBuilder } from '@casl/ability'

--- a/docs/_posts/2017-07-20-define-abilities.md
+++ b/docs/_posts/2017-07-20-define-abilities.md
@@ -142,7 +142,7 @@ console.log(ability.rules)
 
 ## Define own aliases
 
-To define a new alias you can use `addAlias` method which accepts 2 arguments: alias name and one or few action names. For example, here we define `modify` alias to `update` and `delete`
+To define a new alias you can use `addAlias` method which accepts 2 arguments: alias name and one or few action names. For example, here we define `modify` alias to `update` and `delete`. While checking abilities, you can then use the action names `update` or `delete` to check for the `modify` ability defined in your rules.
 
 ```js
 import { Ability, AbilityBuilder } from '@casl/ability'


### PR DESCRIPTION
I adjusted the addAlias documentation to make it a bit clearer which string is intended to be used during ability checks when you create an alias. The code example makes sense, but our team was a little confused about which argument was the real alias.

I think the confusion lies in the usage of the term "alias". The way the code works, `update` and `delete` are actually aliases for `modify`, because they are the alternative names used in ability checks for the **real** defined rule, `modify`.