### PR TITLE
#103

### DIFF
--- a/packages/casl-mongoose/index.d.ts
+++ b/packages/casl-mongoose/index.d.ts
@@ -26,10 +26,12 @@ export interface AccessibleFieldsSchema extends mongoose.Schema {
     options?: AccessibleFieldsOptions): this
 }
 
-export function accessibleRecordsPlugin(schema: mongoose.Schema): void
+export function accessibleRecordsPlugin(schema: mongoose.Schema, options?: null): void
 
 export interface AccessibleSchema extends mongoose.Schema {
-  plugin(plugin: typeof accessibleRecordsPlugin): this
+  plugin(
+    plugin: typeof accessibleRecordsPlugin,
+    options?: null): this
 }
 
 declare module "mongoose" {


### PR DESCRIPTION
This should solve #103, allowing the type typescript compiler (tsc) to compile and no longer error out.

The `accessibleRecordsPlugin` is given an optional options arg of type `null`. This is needed in order to extend mongoose.Schema correctly. The type of `null` is given because in reality `accessibleRecordsPlugin` has no options.

Not sure if this is the _best_ solution, but atleast it should help people from being blocked because of this.