### PR TITLE
'all' action

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4924,12 +4924,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4944,17 +4946,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5071,7 +5076,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5083,6 +5089,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5097,6 +5104,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -5104,12 +5112,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -5128,6 +5138,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5208,7 +5219,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5220,6 +5232,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5341,6 +5354,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/packages/casl-ability/spec/ability.spec.js
+++ b/packages/casl-ability/spec/ability.spec.js
@@ -460,6 +460,33 @@ describe('Ability', () => {
     })
   })
 
+  describe('`all` action', ()=>{
+    it('allows `all` action', () => {
+      ability = AbilityBuilder.define((can, cannot) => {
+        can('all', 'all')
+      })
+
+      expect(ability).to.allow('read', 'post')
+    })
+
+    it('cannot is still honoured', () => {
+      ability = AbilityBuilder.define((can, cannot) => {
+        cannot('read', 'post')
+        can('all', 'all')
+      })
+
+      expect(ability).not.to.allow('read', 'post')
+    })
+
+    it('fields are still honoured', () => {
+      ability = AbilityBuilder.define((can, cannot) => {
+        can('all', 'all', 'subject')
+      })
+
+      expect(ability).to.allow('read', 'post', 'subject')
+    })
+  });
+
   describe('`rulesFor`', () => {
     it('returns rules for specific subject and action', () => {
       ability = AbilityBuilder.define((can, cannot) => {

--- a/packages/casl-ability/src/ability.js
+++ b/packages/casl-ability/src/ability.js
@@ -21,6 +21,10 @@ export class Ability {
     return this;
   }
 
+  static possibleRulesForAction(action, subjectRules) {
+    return (subjectRules[action] || []).concat(subjectRules.all || []);
+  }
+
   constructor(rules, { RuleType = Rule, subjectName = getSubjectName } = {}) {
     this[PRIVATE_FIELD] = {
       RuleType,
@@ -111,8 +115,9 @@ export class Ability {
   possibleRulesFor(action, subject) {
     const subjectName = this[PRIVATE_FIELD].subjectName(subject);
     const { rules } = this[PRIVATE_FIELD];
-    const specificRules = rules.hasOwnProperty(subjectName) ? rules[subjectName][action] : null;
-    const generalRules = rules.hasOwnProperty('all') ? rules.all[action] : null;
+    const specificRules = rules.hasOwnProperty(subjectName)
+      ? Ability.possibleRulesForAction(action, rules[subjectName]) : null;
+    const generalRules = rules.hasOwnProperty('all') ? Ability.possibleRulesForAction(action, rules.all) : null;
 
     return (specificRules || []).concat(generalRules || []);
   }

--- a/packages/casl-angular/package-lock.json
+++ b/packages/casl-angular/package-lock.json
@@ -653,12 +653,14 @@
 				"balanced-match": {
 					"version": "1.0.0",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"balanced-match": "^1.0.0",
 						"concat-map": "0.0.1"
@@ -673,17 +675,20 @@
 				"code-point-at": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"concat-map": {
 					"version": "0.0.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
@@ -800,7 +805,8 @@
 				"inherits": {
 					"version": "2.0.3",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"ini": {
 					"version": "1.3.5",
@@ -812,6 +818,7 @@
 					"version": "1.0.0",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -826,6 +833,7 @@
 					"version": "3.0.4",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"brace-expansion": "^1.1.7"
 					}
@@ -833,12 +841,14 @@
 				"minimist": {
 					"version": "0.0.8",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"minipass": {
 					"version": "2.2.4",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"safe-buffer": "^5.1.1",
 						"yallist": "^3.0.0"
@@ -857,6 +867,7 @@
 					"version": "0.5.1",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"minimist": "0.0.8"
 					}
@@ -937,7 +948,8 @@
 				"number-is-nan": {
 					"version": "1.0.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
@@ -949,6 +961,7 @@
 					"version": "1.4.0",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"wrappy": "1"
 					}
@@ -1070,6 +1083,7 @@
 					"version": "1.0.2",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",


### PR DESCRIPTION
Added the 'all' action like the 'all' subject.

The main use case is super users that can do anything, except maybe a few tasks.

   ability = AbilityBuilder.define((can, cannot) => {
        cannot('destroy', 'world')
        can('all', 'all')
      })