### PR TITLE
docs(ability): document $elemMatch support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Heavily inspired by [cancan](https://github.com/CanCanCommunity/cancancan).
 
 ## Features
 
-* supports MongoDB like conditions (`$eq`, `$ne`, `$in`, `$all`, `$gt`, `$lt`, `$gte`, `$lte`, `$exists`, `$regex`, field dot notation)
+* supports MongoDB like conditions (`$eq`, `$ne`, `$in`, `$all`, `$gt`, `$lt`, `$gte`, `$lte`, `$exists`, `$regex`, `$elemMatch`, field dot notation)
 * supports direct and inverted rules (i.e., `can` & `cannot`)
 * provides ES6 build, so you are able to shake out unused functionality
 * provides easy integration with [popular frontend frameworks](#4-ui-integration)

--- a/docs/_posts/2017-07-20-define-abilities.md
+++ b/docs/_posts/2017-07-20-define-abilities.md
@@ -261,7 +261,7 @@ You can use dot notation to define conditions on nested objects. Here the post c
 can('delete', 'Post', { 'comments.0': { $exists: false } })
 ```
 
-As you may know already, it's possible to use few MongoDB query operators to define more complex conditions (supports only `$eq`, `$ne`, `$in`, `$all`, `$gt`, `$lt`, `$gte`, `$lte`, `$exists`).
+As you may know already, it's possible to use few MongoDB query operators to define more complex conditions (supports only `$eq`, `$ne`, `$in`, `$all`, `$gt`, `$lt`, `$gte`, `$lte`, `$exists`, `$regexp`, `$elemMatch`).
 
 ## Rules per field
 

--- a/packages/casl-ability/spec/ability.spec.js
+++ b/packages/casl-ability/spec/ability.spec.js
@@ -407,6 +407,16 @@ describe('Ability', () => {
       expect(ability).to.allow('delete', new Post({ title: '[DELETED] title' }))
     })
 
+    it('allows to use mongo like `$elemMatch` condition', () => {
+      ability = AbilityBuilder.define(can => {
+        can('delete', 'Post', { authors: { $elemMatch: { id: 'me-id' } } })
+      })
+
+      expect(ability).not.to.allow('delete', new Post({ authors: [{ id: 'someone-else-id' }] }))
+      expect(ability).to.allow('delete', new Post({ authors: [{ id: 'me-id' }] }))
+      expect(ability).to.allow('delete', new Post({ authors: [{ id: 'someone-else-id' }, { id: 'me-id' }] }))
+    })
+
     it('returns true for `Ability` which contains inverted rule and subject specified as string', () => {
       ability = AbilityBuilder.define((can, cannot) => {
         can('read', 'Post')


### PR DESCRIPTION
I was really thrilled to find this [StackOverflow answer](https://stackoverflow.com/questions/51713053/elemmatch-support-or-alternative/51865336#51865336), so I thought it would be helpful to document it!