### PR TITLE
perf(vue): use vue.observable if available

### DIFF
--- a/packages/casl-vue/src/plugin.js
+++ b/packages/casl-vue/src/plugin.js
@@ -8,11 +8,12 @@ export function abilitiesPlugin(Vue, providedAbility) {
   const defaultAbility = providedAbility || new Ability([]);
 
   function createWatcherFor(ability) {
-    const watcher = new Vue({
-      data: {
-        rules: []
-      }
-    });
+    const dataObject = {
+      rules: []
+    };
+    const watcher = Vue.observable
+      ? Vue.observable(dataObject)
+      : new Vue({ data: dataObject });
 
     ability.on('updated', (event) => {
       watcher.rules = event.rules;


### PR DESCRIPTION
Fixes #184.

I ran the tests with vue-2.6.10 and vue-2.5.22 successfully.