### PR TITLE
fix(extra): fixes edge cases for `rulesToFields` method

### DIFF
--- a/packages/casl-ability/spec/query.spec.js
+++ b/packages/casl-ability/spec/query.spec.js
@@ -8,21 +8,21 @@ function toQuery(ability, action, subject) {
 }
 
 describe('rulesToQuery', () => {
-  it('returns empty object if there are no rules with conditions', () => {
+  it('returns an empty object if there are no rules with conditions', () => {
     const ability = AbilityBuilder.define(can => can('read', 'Post'))
     const query = toQuery(ability, 'read', 'Post')
 
     expect(Object.keys(query)).to.be.empty
   })
 
-  it('returns `null` if empty `Ability` instance is passed', () => {
+  it('returns `null` if an empty `Ability` instance is passed', () => {
     const ability = AbilityBuilder.define(() => {})
     const query = toQuery(ability, 'read', 'Post')
 
     expect(query).to.be.null
   })
 
-  it('returns empty `$or` part if at least one regular rule does not have conditions', () => {
+  it('returns an empty `$or` part if at least one regular rule does not have conditions', () => {
     const ability = AbilityBuilder.define(can => {
       can('read', 'Post', { author: 123 })
       can('read', 'Post')
@@ -32,7 +32,7 @@ describe('rulesToQuery', () => {
     expect(Object.keys(query)).to.be.empty
   })
 
-  it('returns empty `$or` part if rule with conditions defined last', () => {
+  it('returns an empty `$or` part if a rule with conditions defined last', () => {
     const ability = AbilityBuilder.define(can => {
       can('read', 'Post')
       can('read', 'Post', { author: 123 })
@@ -44,6 +44,7 @@ describe('rulesToQuery', () => {
 
   it('returns `null` if specified only inverted rules', () => {
     const ability = AbilityBuilder.define((can, cannot) => {
+      can('read', 'Mind');
       cannot('read', 'Post', { private: true })
     })
     const query = toQuery(ability, 'read', 'Post')
@@ -53,6 +54,7 @@ describe('rulesToQuery', () => {
 
   it('returns `null` if at least one inverted rule does not have conditions', () => {
     const ability = AbilityBuilder.define((can, cannot) => {
+      can('read', 'Mind');
       cannot('read', 'Post', { author: 123 })
       cannot('read', 'Post')
     })
@@ -140,7 +142,7 @@ describe('rulesToQuery', () => {
     })
   })
 
-  it('returns empty `$and` part if inverted rule with conditions defined before regular rule without conditions', () => {
+  it('returns an empty `$and` part if an inverted rule with conditions defined before a regular rule without conditions', () => {
     const ability = AbilityBuilder.define((can, cannot) => {
       can('read', 'Post', { author: 123 })
       cannot('read', 'Post', { private: true })

--- a/packages/casl-ability/spec/rules_to_fields.spec.js
+++ b/packages/casl-ability/spec/rules_to_fields.spec.js
@@ -2,37 +2,115 @@ import { rulesToFields } from '../src/extra'
 import { AbilityBuilder, Ability } from '../src'
 
 describe('rulesToFields', () => {
-  it('returns an empty object for an empty `Ability` instance', () => {
-    const object = rulesToFields(new Ability(), 'read', 'Post')
+  it('returns an empty object if there are no rules with conditions', () => {
+    const ability = AbilityBuilder.define(can => can('read', 'Post'))
+    const query = rulesToFields(ability, 'read', 'Post')
 
-    expect(object).to.be.an('object').and.empty
+    expect(Object.keys(query)).to.be.empty
   })
 
-  it('returns an empty object if `Ability` contains only inverted rules', () => {
-    const ability = AbilityBuilder.define((_, cannot) => {
-      cannot('read', 'Post', { id: 5 })
+  it('returns `null` if an empty `Ability` instance is passed', () => {
+    const ability = AbilityBuilder.define(() => {})
+    const query = rulesToFields(ability, 'read', 'Post')
+
+    expect(query).to.be.null
+  })
+
+  it('returns an empty object if at least one regular rule does not have conditions', () => {
+    const ability = AbilityBuilder.define(can => {
+      can('read', 'Post', { author: 123 })
+      can('read', 'Post')
+    })
+    const query = rulesToFields(ability, 'read', 'Post')
+
+    expect(Object.keys(query)).to.be.empty
+  })
+
+  it('returns an empty object if a rule with conditions defined last', () => {
+    const ability = AbilityBuilder.define(can => {
+      can('read', 'Post')
+      can('read', 'Post', { author: 123 })
+    })
+    const query = rulesToFields(ability, 'read', 'Post')
+
+    expect(Object.keys(query)).to.be.empty
+  })
+
+  it('returns `null` if specified only inverted rules', () => {
+    const ability = AbilityBuilder.define((can, cannot) => {
+      can('read', 'Mind');
       cannot('read', 'Post', { private: true })
     })
-    const object = rulesToFields(ability, 'read', 'Post')
+    const query = rulesToFields(ability, 'read', 'Post')
 
-    expect(object).to.be.an('object').and.empty
+    expect(query).to.be.null
   })
 
-  it('returns an empty object for `Ability` instance with rules without conditions', () => {
-    const ability = AbilityBuilder.define(can => can('read', 'Post'))
-    const object = rulesToFields(ability, 'read', 'Post')
-
-    expect(object).to.be.an('object').and.empty
-  })
-
-  it('extracts field values from direct rule conditions', () => {
-    const ability = AbilityBuilder.define((can) => {
-      can('read', 'Post', { id: 5 })
-      can('read', 'Post', { private: true })
+  it('returns `null` if at least one inverted rule does not have conditions', () => {
+    const ability = AbilityBuilder.define((can, cannot) => {
+      can('read', 'Mind');
+      cannot('read', 'Post', { author: 123 })
+      cannot('read', 'Post')
     })
-    const object = rulesToFields(ability, 'read', 'Post')
+    const query = rulesToFields(ability, 'read', 'Post')
 
-    expect(object).to.deep.equal({ id: 5, private: true })
+    expect(query).to.be.null
+  })
+
+  it('returns `null` if at least one inverted rule does not have conditions even if direct condition exists', () => {
+    const ability = AbilityBuilder.define((can, cannot) => {
+      can('read', 'Post', { public: true })
+      cannot('read', 'Post', { author: 321 })
+      cannot('read', 'Post')
+    })
+    const query = rulesToFields(ability, 'read', 'Post')
+
+    expect(query).to.be.null
+  })
+
+  it('returns non-`null` if there is at least one regular rule after last inverted one without conditions', () => {
+    const ability = AbilityBuilder.define((can, cannot) => {
+      can('read', 'Post', { public: true })
+      cannot('read', 'Post', { author: 321 })
+      cannot('read', 'Post')
+      can('read', 'Post', { author: 123 })
+    })
+    const query = rulesToFields(ability, 'read', 'Post')
+
+    expect(query).to.deep.equal({ author: 123 })
+  })
+
+  it('extracts field values from regular rule conditions', () => {
+    const ability = AbilityBuilder.define(can => {
+      can('read', 'Post', { status: 'draft' })
+      can('read', 'Post', { createdBy: 'me' })
+    })
+    const query = rulesToFields(ability, 'read', 'Post')
+
+    expect(query).to.deep.equal({ status: 'draft', createdBy: 'me' })
+  })
+
+  it('ignores inverted rules with conditions', () => {
+    const ability = AbilityBuilder.define((can, cannot) => {
+      can('read', 'Post', { _id: 'mega' })
+      can('read', 'Post', { state: 'draft' })
+      cannot('read', 'Post', { private: true })
+      cannot('read', 'Post', { state: 'archived' })
+    })
+    const query = rulesToFields(ability, 'read', 'Post')
+
+    expect(query).to.deep.equal({ _id: 'mega', state: 'draft' })
+  })
+
+  it('returns an empty object if an inverted rule with conditions defined before a regular rule without conditions', () => {
+    const ability = AbilityBuilder.define((can, cannot) => {
+      can('read', 'Post', { author: 123 })
+      cannot('read', 'Post', { private: true })
+      can('read', 'Post')
+    })
+    const query = rulesToFields(ability, 'read', 'Post')
+
+    expect(Object.keys(query)).to.be.empty
   })
 
   it('correctly sets values for fields declared with `dot notation`', () => {
@@ -52,7 +130,7 @@ describe('rulesToFields', () => {
 
   it('skips plain object values (i.e., mongo query expressions)', () => {
     const ability = AbilityBuilder.define((can) => {
-      can('read', 'Post', { state: { $in: ['draft', 'review'] } })
+      can('read', 'Post', { status: { $in: ['draft', 'review'] } })
       can('read', 'Post', { private: true })
     })
     const object = rulesToFields(ability, 'read', 'Post')


### PR DESCRIPTION
Next step: make `rulesToFields` behaviour consistent with `rulesToQuery` and `permittedFieldsOf`.

In current tests for `rulesToFields` there are no cases of mixes between conditioned regular rules, unconditional regular rules and unconditional reverse rules.

Also, unlike `rulesToQuery` and `permittedFieldsOf`, `rulesToFields` will produce the same result for an ability which unconditionally can do thing and an ability which unconditionally cannot do same thing - empty object. (While `rulesToQuery` returns an empty object vs null and `permittedFieldsOf` returns a full array vs an empty array.)

Copied and adapted tests from `rulesToQuery` where they make sense. Look at resulted tests in this pull request and see if any of them do not make sense for you.

Here is some cases illustrated in snippet form:

```js
can('create', 'Post')
cannot('create', 'Post')
// now: null
// before: {}

can('create', 'Post', {public: true})
cannot('create', 'Post')
// now: null
// before: {public: true}

can('create', 'Post', {public: true})
can('create', 'Post')
// now: {}
// before: {public: true}

can('create', 'Post')
can('create', 'Post', {public: true})
// now: {}
// before: {public: true}

can('create', 'Post', {public: true})
cannot('create', 'Post')
can('create', 'Post', {author: 1})
// now: {author: 1}
// before: {author: 1, public: true}
```