### PR TITLE
Fix erroneous references to mongoDB `$regexp`

### DIFF
--- a/docs/_posts/2017-07-20-define-abilities.md
+++ b/docs/_posts/2017-07-20-define-abilities.md
@@ -261,7 +261,7 @@ You can use dot notation to define conditions on nested objects. Here the post c
 can('delete', 'Post', { 'comments.0': { $exists: false } })
 ```
 
-As you may know already, it's possible to use few MongoDB query operators to define more complex conditions (supports only `$eq`, `$ne`, `$in`, `$all`, `$gt`, `$lt`, `$gte`, `$lte`, `$exists`, `$regexp`, `$elemMatch`).
+As you may know already, it's possible to use few MongoDB query operators to define more complex conditions (supports only `$eq`, `$ne`, `$in`, `$all`, `$gt`, `$lt`, `$gte`, `$lte`, `$exists`, `$regex`, `$elemMatch`).
 
 ## Rules per field
 

--- a/packages/casl-ability/spec/ability.spec.js
+++ b/packages/casl-ability/spec/ability.spec.js
@@ -406,7 +406,7 @@ describe('Ability', () => {
       expect(ability).to.allow('update', new Post({ state: complexValue('draft') }))
     })
 
-    it('allows to use mongo like `$regexp` condition', () => {
+    it('allows to use mongo like `$regex` condition', () => {
       ability = AbilityBuilder.define((can) => {
         can('delete', 'Post', { title: { $regex: '\\[DELETED\\]' } })
       })


### PR DESCRIPTION
Following the docs, I was setting up conditions with `$regexp`, however,  that was throwing ugly errors and causing my seeder to fail.

```
Error: Unknown operation $regexp
    at parse (/projectRoot/node_modules/@casl/ability/node_modules/sift/lib/index.js:499:15)
    at parse (/projectRoot/node_modules/@casl/ability/node_modules/sift/lib/index.js:501:61)
    at createRootValidator (/projectRoot/node_modules/@casl/ability/node_modules/sift/lib/index.js:512:19)
    at sift (/projectRoot/node_modules/@casl/ability/node_modules/sift/lib/index.js:534:19)
    at new e (/projectRoot/node_modules/@casl/ability/dist/umd/index.js:1:1282)
    at e.t.buildIndexFor (/projectRoot/node_modules/@casl/ability/dist/umd/index.js:1:2698)
    at e.t.update (/projectRoot/node_modules/@casl/ability/dist/umd/index.js:1:2497)
    at new e (/projectRoot/node_modules/@casl/ability/dist/umd/index.js:1:2043)
    at AbilitiesSeeder.seedCoreModule (/projectRoot/src/api/services/abilities/seed.js:227:29)
    at AbilitiesSeeder.seedCoreModule [as run] (/projectRoot/src/api/services/abilities/seed.js:56:14)
```

Unlike the (poorly named IMHO) javascript `RegExp`, mongo uses `$regex`.

This PR updates the the title of the `$regex` text case, and the docs.