### PR TITLE
Fixed `$and` condition being overridden on queries

### DIFF
--- a/packages/casl-mongoose/package.json
+++ b/packages/casl-mongoose/package.json
@@ -14,7 +14,7 @@
   },
   "homepage": "https://stalniy.github.io/casl/",
   "scripts": {
-    "build": "BUILD_TYPES=es6,umd:cjs rollup -c ../../tools/rollup.config.js -e @casl/ability/extra",
+    "build": "BUILD_TYPES=es6,umd:cjs rollup -c ../../tools/rollup.config.js -e @casl/ability/extra,mongoose",
     "lint": "eslint src/",
     "test": "NODE_ENV=test jest --config ../../tools/jest.config.js --env node",
     "prerelease": "npm test && NODE_ENV=production npm run build",

--- a/packages/casl-mongoose/src/accessible_records.js
+++ b/packages/casl-mongoose/src/accessible_records.js
@@ -1,3 +1,4 @@
+import { Query } from 'mongoose';
 import { toMongoQuery } from './mongo';
 
 const DENY_CONDITION_NAME = '__forbiddenByCasl__';
@@ -32,7 +33,11 @@ function emptyQuery(query) {
 function accessibleBy(ability, action) {
   const query = toMongoQuery(ability, this.modelName || this.model.modelName, action);
 
-  return query === null ? emptyQuery(this.where()) : this.where({ $and: [query] });
+  if (query === null) {
+    return emptyQuery(this.where());
+  }
+
+  return this instanceof Query ? this.and([query]) : this.where({ $and: [query] });
 }
 
 export function accessibleRecordsPlugin(schema) {


### PR DESCRIPTION
Fixes https://github.com/stalniy/casl/issues/272

In order to test I needed to check the "private" attribute `_conditions` on the query. This probably isn't preferable but I wasn't able to think of another way. If you happen to know of one I'll gladly make the change