### PR TITLE
Add types for useAbility

### DIFF
--- a/packages/casl-react/tsconfig.json
+++ b/packages/casl-react/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig",
   "include": [
-    "src/*"
+    "src/**/*.ts
   ],
   "compilerOptions": {
     "outDir": "dist/types",


### PR DESCRIPTION
This should as far as I am aware will add the types for useAbility into the index.d.ts file when built