### PR TITLE
chore(deps): updates angular to v12

### DIFF
--- a/packages/casl-angular/README.md
+++ b/packages/casl-angular/README.md
@@ -4,9 +4,11 @@
 [![](https://img.shields.io/npm/dm/%40casl%2Fangular.svg)](https://www.npmjs.com/package/%40casl%2Fangular)
 [![CASL Join the chat](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/stalniy-casl/casl)
 
-This package allows to integrate `@casl/ability` with [Angular] application. It provides `AblePipe` and **deprecated** `CanPipe` to Angular templates, so you can show or hide components, buttons, etc based on user ability to see them.
+This package allows to integrate `@casl/ability` with [Angular] application. It provides `AblePipe` and `AblePurePipe` to Angular templates, so you can show or hide components, buttons, etc based on user ability to see them.
 
 ## Installation
+
+The latest version of this package is compiled by Ivy, so **apps that do not use Ivy are no longer supported.**
 
 ```sh
 npm install @casl/angular @casl/ability
@@ -39,7 +41,7 @@ import { Ability, PureAbility } from '@casl/ability';
 export class AppModule {}
 ```
 
-The 2nd provider provides instance of `PureAbility`, so `CanPipe` and `AblePipe` can inject it later. This pipes inject `PureAbility` (not `Ability`) because this allows an application developer to decide how to configure actions, subjects and conditions. Also this is the only way to get maximum from tree shaking (e.g., if you don't need conditions you can use `PureAbility` and get rid of `sift` library).
+The 2nd provider provides instance of `PureAbility`, so pipes can inject it later. This pipes inject `PureAbility` (not `Ability`) because this allows an application developer to decide how to configure actions, subjects and conditions. Also this is the only way to get maximum from tree shaking (e.g., if you don't need conditions you can use `PureAbility` and shrink @casl/ability size).
 
 > Read [CASL and TypeScript](https://casl.js.org/v5/en/advanced/typescript) to get more details about `Ability` type configuration.
 
@@ -130,16 +132,6 @@ To check permissions in any template you can use `AblePipe`:
 ```
 
 > You can read the expression in `ngIf` as "if creatable Post"
-
-Or with **deprecated** `CanPipe`:
-
-```html
-<div *ngIf="'Post' | can: 'create'">
-  <a (click)="createPost()">Add Post</a>
-</div>
-```
-
-`CanPipe` was deprecated because it is less readable and it was harder to integrate it with all type definitions supported by `Ability`'s `can` method. That's why `CanPipe` has weaker typings than `AblePipe`.
 
 ## Why pipe and not directive?
 

--- a/packages/casl-angular/package.json
+++ b/packages/casl-angular/package.json
@@ -4,11 +4,11 @@
   "description": "Angular module for CASL which makes it easy to add permissions in any Angular app",
   "main": "dist/umd/index.js",
   "module": "dist/es5m/index.js",
-  "es2015": "dist/es6m/index.js",
+  "es2015": "dist/es6m/index.mjs",
   "typings": "dist/types/index.d.ts",
   "exports": {
     ".": {
-      "import": "./dist/es6m/index.js",
+      "import": "./dist/es6m/index.mjs",
       "require": "./dist/umd/index.js"
     }
   },
@@ -26,9 +26,9 @@
     "build.es5m": "TARGET=es5 BUILD=es5m npm run rollup",
     "build.es6": "TARGET=es2015 BUILD=es6m npm run rollup",
     "build.umd": "TARGET=es5 BUILD=umd npm run rollup",
-    "build.types": "ngc -p tsconfig.types.json",
+    "build.types": "ngc -p tsconfig.types.json && rm -rf dist/types/*.js",
     "prerollup": "ngc -p tsconfig.build.json --target $TARGET --outDir dist/$BUILD/tmp",
-    "rollup": "IGNORE_SUBPATH=1 LIB_MINIFY=false BUILD_TYPES=$BUILD ES_TRANSFORM=false ES6M_EXT=.js dx rollup -i dist/$BUILD/tmp/index.js -n casl.ng -g @angular/core:ng.core,@casl/ability:casl,tslib:tslib,rxjs:rxjs",
+    "rollup": "IGNORE_SUBPATH=1 LIB_MINIFY=false BUILD_TYPES=$BUILD ES_TRANSFORM=false dx rollup -i dist/$BUILD/tmp/index.js -n casl.ng -g @angular/core:ng.core,@casl/ability:casl,tslib:tslib,rxjs:rxjs",
     "postrollup": "rm -rf dist/$BUILD/tmp",
     "test": "dx jest --config ./jest.config.js",
     "lint": "dx eslint src/ spec/",
@@ -45,24 +45,25 @@
   "author": "Sergii Stotskyi <sergiy.stotskiy@gmail.com>",
   "license": "MIT",
   "peerDependencies": {
-    "@angular/core": "^9.0.0 || ^10.0.0 || ^11.0.0",
+    "@angular/core": "^12.0.0",
     "@casl/ability": "^3.0.0 || ^4.0.0 || ^5.1.0",
-    "rxjs": "^6.0.0",
+    "rxjs": "^6.5.3",
     "tslib": "^2.0.0"
   },
   "devDependencies": {
-    "@abraham/reflection": "^0.7.0",
-    "@angular/common": "^11.0.0",
-    "@angular/compiler": "^11.0.0",
-    "@angular/compiler-cli": "^11.0.0",
-    "@angular/core": "^11.0.0",
-    "@angular/platform-browser": "^11.0.0",
-    "@angular/platform-browser-dynamic": "^11.0.0",
+    "@abraham/reflection": "^0.8.0",
+    "@angular/common": "^12.0.0",
+    "@angular/compiler": "^12.0.0",
+    "@angular/compiler-cli": "^12.0.0",
+    "@angular/core": "^12.0.0",
+    "@angular/platform-browser": "^12.0.0",
+    "@angular/platform-browser-dynamic": "^12.0.0",
     "@casl/ability": "^5.1.0",
     "@casl/dx": "workspace:^1.0.0",
-    "rxjs": "^6.0.0",
+    "rxjs": "^6.5.3",
     "tslib": "^2.0.0",
-    "zone.js": "^0.10.2"
+    "typescript": "~4.2.3",
+    "zone.js": "~0.11.4"
   },
   "files": [
     "dist",

--- a/packages/casl-angular/spec/AbilityModule.e2e.spec.ts
+++ b/packages/casl-angular/spec/AbilityModule.e2e.spec.ts
@@ -2,7 +2,6 @@ import { PureAbility } from '@casl/ability'
 import { TestBed } from '@angular/core/testing'
 import { createApp, createComponent, configureTestingModule, Post } from './spec_helper'
 
-const AppWithCanPipe = createApp('{{ post | can: \'read\' }}')
 const AppWithAblePipe = createApp('{{ \'read\' | able: post }}')
 const AppWithAblePurePipe = createApp('{{ \'read\' | ablePure: post | async }}')
 
@@ -19,8 +18,8 @@ describe('Ability pipes', () => {
 
   describe('module', () => {
     it('provides deprecated impure `can` pipe', () => {
-      configureTestingModule([AppWithCanPipe])
-      fixture = createComponent(AppWithCanPipe)
+      configureTestingModule([AppWithAblePurePipe])
+      fixture = createComponent(AppWithAblePurePipe)
       expect(fixture.nativeElement.textContent).toBe('false')
     })
 
@@ -29,10 +28,6 @@ describe('Ability pipes', () => {
       fixture = createComponent(AppWithAblePipe)
       expect(fixture.nativeElement.textContent).toBe('false')
     })
-  })
-
-  describe('`can` pipe', () => {
-    behavesLikeAbilityPipe(AppWithCanPipe)
   })
 
   describe('`able` pipe', () => {

--- a/packages/casl-angular/spec/AblePipe.spec.ts
+++ b/packages/casl-angular/spec/AblePipe.spec.ts
@@ -1,16 +1,13 @@
-import { ChangeDetectorRef } from '@angular/core'
 import { defineAbility, Ability } from '@casl/ability'
 import { AblePipe } from '../src/public'
 
 describe('Can pipe', () => {
   let ability: Ability
   let pipe: AblePipe<any>
-  let changeDetectorRef: ChangeDetectorRef
 
   beforeEach(() => {
     ability = defineAbility<Ability>(can => can('read', 'all'))
-    changeDetectorRef = { markForCheck: jest.fn() } as unknown as ChangeDetectorRef
-    pipe = new AblePipe(ability, changeDetectorRef)
+    pipe = new AblePipe(ability)
   })
 
   it('calls underlying `ability` `can` method', () => {
@@ -18,26 +15,5 @@ describe('Can pipe', () => {
     pipe.transform('read', 'Post')
 
     expect(can).toHaveBeenCalledWith('read', 'Post')
-  })
-
-  it('marks change detector as dirty when ability updates', () => {
-    pipe.transform('read', 'Post')
-    ability.update([])
-
-    expect(changeDetectorRef.markForCheck).toHaveBeenCalled()
-  })
-
-  it('does not subscribes to ability updates if it has not been executed', () => {
-    ability.update([])
-
-    expect(changeDetectorRef.markForCheck).not.toHaveBeenCalled()
-  })
-
-  it('unsubscribes from ability when destroyed', () => {
-    pipe.transform('read', 'Post')
-    pipe.ngOnDestroy()
-    ability.update([])
-
-    expect(changeDetectorRef.markForCheck).not.toHaveBeenCalled()
   })
 })

--- a/packages/casl-angular/src/AbilityModule.ts
+++ b/packages/casl-angular/src/AbilityModule.ts
@@ -1,14 +1,12 @@
 import { NgModule } from '@angular/core';
-import { CanPipe, AblePipe, AblePurePipe } from './pipes';
+import { AblePipe, AblePurePipe } from './pipes';
 
 @NgModule({
   declarations: [
-    CanPipe,
     AblePipe,
     AblePurePipe,
   ],
   exports: [
-    CanPipe,
     AblePipe,
     AblePurePipe,
   ],

--- a/packages/casl-angular/src/pipes.ts
+++ b/packages/casl-angular/src/pipes.ts
@@ -1,66 +1,18 @@
-import { Pipe, ChangeDetectorRef, Inject, PipeTransform } from '@angular/core';
+import { Pipe, Inject, PipeTransform } from '@angular/core';
 import { PureAbility, Unsubscribe, AnyAbility } from '@casl/ability';
 import { Observable } from 'rxjs';
 
-class AbilityPipe<T extends AnyAbility> {
-  protected _unsubscribeFromAbility?: Unsubscribe;
-  private _ability: T;
-  private _cd: ChangeDetectorRef;
-
-  constructor(ability: T, cd: ChangeDetectorRef) {
-    this._ability = ability;
-    this._cd = cd;
-  }
-
-  transform(...args: Parameters<T['can']>): boolean {
-    if (!this._unsubscribeFromAbility) {
-      this._unsubscribeFromAbility = this._ability.on('updated', () => this._cd.markForCheck());
-    }
-    return this._ability.can(...args);
-  }
-
-  ngOnDestroy() {
-    if (this._unsubscribeFromAbility) {
-      this._unsubscribeFromAbility();
-    }
-  }
-}
-
-@Pipe({ name: 'can', pure: false })
-export class CanPipe<T extends AnyAbility> implements PipeTransform {
-  protected pipe: AbilityPipe<T>;
-
-  constructor(@Inject(PureAbility) ability: T, cd: ChangeDetectorRef) {
-    this.pipe = new AbilityPipe(ability, cd);
-  }
-
-  transform(
-    subject: Parameters<T['can']>[1],
-    action: Parameters<T['can']>[0],
-    field?: string
-  ): boolean {
-    return (this.pipe as any).transform(action, subject, field);
-  }
-
-  ngOnDestroy() {
-    this.pipe.ngOnDestroy();
-  }
-}
-
 @Pipe({ name: 'able', pure: false })
 export class AblePipe<T extends AnyAbility> implements PipeTransform {
-  protected pipe: AbilityPipe<T>;
+  protected _unsubscribeFromAbility?: Unsubscribe;
+  private _ability: T;
 
-  constructor(@Inject(PureAbility) ability: T, cd: ChangeDetectorRef) {
-    this.pipe = new AbilityPipe(ability, cd);
+  constructor(@Inject(PureAbility) ability: T) {
+    this._ability = ability;
   }
 
   transform(...args: Parameters<T['can']>): boolean {
-    return this.pipe.transform(...args);
-  }
-
-  ngOnDestroy() {
-    this.pipe.ngOnDestroy();
+    return this._ability.can(...args);
   }
 }
 

--- a/packages/casl-angular/tsconfig.json
+++ b/packages/casl-angular/tsconfig.json
@@ -24,10 +24,8 @@
     "spec/*"
   ],
   "angularCompilerOptions": {
-    "enableIvy": false,
+    "enableIvy": true,
     "skipMetadataEmit": true,
-    "skipTemplateCodegen": true,
-    "strictInjectionParameters": true,
     "flatModuleOutFile": "index.js",
     "flatModuleId": "@casl/angular"
   }

--- a/packages/casl-angular/tsconfig.types.json
+++ b/packages/casl-angular/tsconfig.types.json
@@ -1,7 +1,6 @@
 {
   "extends": "./tsconfig.build.json",
   "compilerOptions": {
-    "emitDeclarationOnly": true,
     "declaration": true,
     "outDir": "dist/types"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,31 +29,33 @@ importers:
 
   packages/casl-angular:
     specifiers:
-      '@abraham/reflection': ^0.7.0
-      '@angular/common': ^11.0.0
-      '@angular/compiler': ^11.0.0
-      '@angular/compiler-cli': ^11.0.0
-      '@angular/core': ^11.0.0
-      '@angular/platform-browser': ^11.0.0
-      '@angular/platform-browser-dynamic': ^11.0.0
+      '@abraham/reflection': ^0.8.0
+      '@angular/common': ^12.0.0
+      '@angular/compiler': ^12.0.0
+      '@angular/compiler-cli': ^12.0.0
+      '@angular/core': ^12.0.0
+      '@angular/platform-browser': ^12.0.0
+      '@angular/platform-browser-dynamic': ^12.0.0
       '@casl/ability': ^5.1.0
       '@casl/dx': workspace:^1.0.0
-      rxjs: ^6.0.0
+      rxjs: ^6.5.3
       tslib: ^2.0.0
-      zone.js: ^0.10.2
+      typescript: ~4.2.3
+      zone.js: ~0.11.4
     devDependencies:
-      '@abraham/reflection': 0.7.0
-      '@angular/common': 11.2.11_@angular+core@11.2.11+rxjs@6.6.7
-      '@angular/compiler': 11.2.11
-      '@angular/compiler-cli': 11.2.11_@angular+compiler@11.2.11
-      '@angular/core': 11.2.11_rxjs@6.6.7+zone.js@0.10.3
-      '@angular/platform-browser': 11.2.11_f5339324adb1f45359ceef88112acaf4
-      '@angular/platform-browser-dynamic': 11.2.11_1c30067bfb1a3b1328a6ee03011e09bd
+      '@abraham/reflection': 0.8.0
+      '@angular/common': 12.0.2_@angular+core@12.0.2+rxjs@6.6.7
+      '@angular/compiler': 12.0.2
+      '@angular/compiler-cli': 12.0.2_1a86491d0247c39537700a37e466e67e
+      '@angular/core': 12.0.2_rxjs@6.6.7+zone.js@0.11.4
+      '@angular/platform-browser': 12.0.2_56e2dfbae1bbe9751ca4becbb00c593f
+      '@angular/platform-browser-dynamic': 12.0.2_993d4b7e7309e8e890db12e9e610ae8a
       '@casl/ability': link:../casl-ability
       '@casl/dx': link:../dx
       rxjs: 6.6.7
       tslib: 2.2.0
-      zone.js: 0.10.3
+      typescript: 4.2.4
+      zone.js: 0.11.4
 
   packages/casl-aurelia:
     specifiers:
@@ -196,93 +198,98 @@ importers:
 
 packages:
 
-  /@abraham/reflection/0.7.0:
-    resolution: {integrity: sha512-W4V4I0PzxeWCiMKnS4n4x3Fzb8cQp2qlmBO7RACS/00YsvIgijjcBz5Mp3P1PPP9vSzpbmi0qwuVYZ4twXKwxg==}
+  /@abraham/reflection/0.8.0:
+    resolution: {integrity: sha512-Oy2jk9hHEI/t1avTgB4BCQtceUOqwrElQdecGS0wTqH5rc0KXysUrhpX4ep0vCMjoxzNyXSx7JU+KWkrkFIKOg==}
     dev: true
 
-  /@angular/common/11.2.11_@angular+core@11.2.11+rxjs@6.6.7:
-    resolution: {integrity: sha512-q2chMuaJxN1994Jm3ptWLIWx/yE0P4LCYAef7H10tYDXEJUWY9Tul+4YAnDeBjLY7om8/x3jUKChhfkuuWJing==}
+  /@angular/common/12.0.2_@angular+core@12.0.2+rxjs@6.6.7:
+    resolution: {integrity: sha512-KJFtqdIGVrF97iK3zcN9FoQ1fDsc/u4ez1Qtx0HdH21qAuAvK/FYybg4r1G6miXoUJcO8hu9oRddEoiNPkXAew==}
+    engines: {node: ^12.14.1 || >=14.0.0}
     peerDependencies:
-      '@angular/core': 11.2.11
+      '@angular/core': 12.0.2
       rxjs: ^6.5.3
     dependencies:
-      '@angular/core': 11.2.11_rxjs@6.6.7+zone.js@0.10.3
+      '@angular/core': 12.0.2_rxjs@6.6.7+zone.js@0.11.4
       rxjs: 6.6.7
       tslib: 2.2.0
     dev: true
 
-  /@angular/compiler-cli/11.2.11_@angular+compiler@11.2.11:
-    resolution: {integrity: sha512-RaXldtUmtPFQGmiRM/W9EFQ6C0Wx+llQWrFl+Bo4tcyE9JQ1jaQKYPJStJrv9ljV9RFyiPM3O00kad6QYqUdfQ==}
-    engines: {node: '>=10.0'}
+  /@angular/compiler-cli/12.0.2_1a86491d0247c39537700a37e466e67e:
+    resolution: {integrity: sha512-ocm/c4ZcdtlvMSlN1L6Asyx4nYC4qA0j3+H3mKl/ds8bq/8Gb9cxOiu3hqmUKgovXF/Wue6orsWLzHowuxfagA==}
+    engines: {node: ^12.14.1 || >=14.0.0}
     hasBin: true
     peerDependencies:
-      '@angular/compiler': 11.2.11
-      typescript: '>=4.0 <4.2'
+      '@angular/compiler': 12.0.2
+      typescript: '>=4.2.3 <4.3'
     dependencies:
-      '@angular/compiler': 11.2.11
-      '@babel/core': 7.13.16
-      '@babel/types': 7.13.17
+      '@angular/compiler': 12.0.2
+      '@babel/core': 7.14.0
+      '@babel/types': 7.14.1
       canonical-path: 1.0.0
       chokidar: 3.5.1
       convert-source-map: 1.7.0
-      dependency-graph: 0.7.2
-      fs-extra: 4.0.2
+      dependency-graph: 0.11.0
       magic-string: 0.25.7
       minimist: 1.2.5
       reflect-metadata: 0.1.13
-      semver: 6.3.0
+      semver: 7.3.5
       source-map: 0.6.1
       sourcemap-codec: 1.4.8
       tslib: 2.2.0
+      typescript: 4.2.4
       yargs: 16.2.0
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@angular/compiler/11.2.11:
-    resolution: {integrity: sha512-8hJcT6oH/XGfE8DrCG9/PJR+FMsAAs2zT40c8mAuXa0qSn3Yrg/g1sHZ1eTwdU3iNIKzpoPj33MkJSoGN26NAQ==}
+  /@angular/compiler/12.0.2:
+    resolution: {integrity: sha512-PLkDb1mxWpsOJwR0t9yDI8A9dSMUEmVf+HdNWFO1aFY84nZ3sH8t6e/BpoaRcbLJCkNgtm9YD8FmRHE30LZ3CA==}
+    engines: {node: ^12.14.1 || >=14.0.0}
     dependencies:
       tslib: 2.2.0
     dev: true
 
-  /@angular/core/11.2.11_rxjs@6.6.7+zone.js@0.10.3:
-    resolution: {integrity: sha512-O6/opXdOwsAznpactC68TfX8RSErELfyzYGSoNpejDEFdflm0E2jSF4CcdCBlk6WtAJlnL587Lyr9o7AemI0TA==}
+  /@angular/core/12.0.2_rxjs@6.6.7+zone.js@0.11.4:
+    resolution: {integrity: sha512-RBTl8L2ckSI3n2lo9rmwlUeZAuEd/TWUjoidoxPYWrKfbnFwKX65idCCbWLJivSVIBnPQYvAdC+3k4w40N9AWA==}
+    engines: {node: ^12.14.1 || >=14.0.0}
     peerDependencies:
       rxjs: ^6.5.3
-      zone.js: ^0.10.2 || ^0.11.3
+      zone.js: ~0.11.4
     dependencies:
       rxjs: 6.6.7
       tslib: 2.2.0
-      zone.js: 0.10.3
+      zone.js: 0.11.4
     dev: true
 
-  /@angular/platform-browser-dynamic/11.2.11_1c30067bfb1a3b1328a6ee03011e09bd:
-    resolution: {integrity: sha512-ldySv63ceIU+KvVYqK1RKkaYxolgC859sp31LPlzAoDbAMnCMB1txRGkiiwUZ6pqph5C3LBsxFTqrLZyNcnNKQ==}
+  /@angular/platform-browser-dynamic/12.0.2_993d4b7e7309e8e890db12e9e610ae8a:
+    resolution: {integrity: sha512-FVJBIxn85EX3a6kSdqwXAC8i7jxeo5iwHBKUEFYukbAXrHuMmwFz7Nvqkqqo0xIJXymFz8Q04VbTThkgp2uerg==}
+    engines: {node: ^12.14.1 || >=14.0.0}
     peerDependencies:
-      '@angular/common': 11.2.11
-      '@angular/compiler': 11.2.11
-      '@angular/core': 11.2.11
-      '@angular/platform-browser': 11.2.11
+      '@angular/common': 12.0.2
+      '@angular/compiler': 12.0.2
+      '@angular/core': 12.0.2
+      '@angular/platform-browser': 12.0.2
     dependencies:
-      '@angular/common': 11.2.11_@angular+core@11.2.11+rxjs@6.6.7
-      '@angular/compiler': 11.2.11
-      '@angular/core': 11.2.11_rxjs@6.6.7+zone.js@0.10.3
-      '@angular/platform-browser': 11.2.11_f5339324adb1f45359ceef88112acaf4
+      '@angular/common': 12.0.2_@angular+core@12.0.2+rxjs@6.6.7
+      '@angular/compiler': 12.0.2
+      '@angular/core': 12.0.2_rxjs@6.6.7+zone.js@0.11.4
+      '@angular/platform-browser': 12.0.2_56e2dfbae1bbe9751ca4becbb00c593f
       tslib: 2.2.0
     dev: true
 
-  /@angular/platform-browser/11.2.11_f5339324adb1f45359ceef88112acaf4:
-    resolution: {integrity: sha512-5DwczcZHRDh9E+hfzoGC+lfbJe95w8C1mg0EFtxxeGbdtaAXGzlfhDWvLceB5cpd8UNRVY7QvOZ/erfH2i3QTw==}
+  /@angular/platform-browser/12.0.2_56e2dfbae1bbe9751ca4becbb00c593f:
+    resolution: {integrity: sha512-m1tPOpNZdnp8jrtFP3FrjpBV+S/rd5HLd4Q9MaC62LJYf8VvRx8wKdUO8tBDJYPbGiHGL4q4BUvKswrzfFWbXg==}
+    engines: {node: ^12.14.1 || >=14.0.0}
     peerDependencies:
-      '@angular/animations': 11.2.11
-      '@angular/common': 11.2.11
-      '@angular/core': 11.2.11
+      '@angular/animations': 12.0.2
+      '@angular/common': 12.0.2
+      '@angular/core': 12.0.2
     peerDependenciesMeta:
       '@angular/animations':
         optional: true
     dependencies:
-      '@angular/common': 11.2.11_@angular+core@11.2.11+rxjs@6.6.7
-      '@angular/core': 11.2.11_rxjs@6.6.7+zone.js@0.10.3
+      '@angular/common': 12.0.2_@angular+core@12.0.2+rxjs@6.6.7
+      '@angular/core': 12.0.2_rxjs@6.6.7+zone.js@0.11.4
       tslib: 2.2.0
     dev: true
 
@@ -303,29 +310,6 @@ packages:
 
   /@babel/compat-data/7.14.0:
     resolution: {integrity: sha512-vu9V3uMM/1o5Hl5OekMUowo3FqXLJSw+s+66nt0fSWVWTtmosdzn45JHOB3cPtZoe6CTBDzvSw0RdOY85Q37+Q==}
-
-  /@babel/core/7.13.16:
-    resolution: {integrity: sha512-sXHpixBiWWFti0AV2Zq7avpTasr6sIAu7Y396c608541qAU2ui4a193m0KSQmfPSKFZLnQ3cvlKDOm3XkuXm3Q==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/code-frame': 7.12.13
-      '@babel/generator': 7.13.16
-      '@babel/helper-compilation-targets': 7.13.16_@babel+core@7.13.16
-      '@babel/helper-module-transforms': 7.13.14
-      '@babel/helpers': 7.13.17
-      '@babel/parser': 7.13.16
-      '@babel/template': 7.12.13
-      '@babel/traverse': 7.13.17
-      '@babel/types': 7.13.17
-      convert-source-map: 1.7.0
-      debug: 4.3.1
-      gensync: 1.0.0-beta.2
-      json5: 2.2.0
-      semver: 6.3.0
-      source-map: 0.5.7
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
 
   /@babel/core/7.14.0:
     resolution: {integrity: sha512-8YqpRig5NmIHlMLw09zMlPTvUVMILjqCOtVgu+TVNWEBvy9b5I3RRyhqnrV4hjgEK7n8P9OqvkWJAFmEL6Wwfw==}
@@ -348,15 +332,6 @@ packages:
       source-map: 0.5.7
     transitivePeerDependencies:
       - supports-color
-    dev: false
-
-  /@babel/generator/7.13.16:
-    resolution: {integrity: sha512-grBBR75UnKOcUWMp8WoDxNsWCFl//XCK6HWTrBQKTr5SV9f5g0pNOjdyzi/DTBv12S9GnYPInIXQBTky7OXEMg==}
-    dependencies:
-      '@babel/types': 7.13.17
-      jsesc: 2.5.2
-      source-map: 0.5.7
-    dev: true
 
   /@babel/generator/7.14.1:
     resolution: {integrity: sha512-TMGhsXMXCP/O1WtQmZjpEYDhCYC9vFhayWZPJSZCGkPJgUqX0rF0wwtrYvnzVxIjcF80tkUertXVk5cwqi5cAQ==}
@@ -378,18 +353,6 @@ packages:
       '@babel/types': 7.14.1
     dev: false
 
-  /@babel/helper-compilation-targets/7.13.16_@babel+core@7.13.16:
-    resolution: {integrity: sha512-3gmkYIrpqsLlieFwjkGgLaSHmhnvlAYzZLlYVjlW+QwI+1zE17kGxuJGmIqDQdYp56XdmGeD+Bswx0UTyG18xA==}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-    dependencies:
-      '@babel/compat-data': 7.14.0
-      '@babel/core': 7.13.16
-      '@babel/helper-validator-option': 7.12.17
-      browserslist: 4.16.6
-      semver: 6.3.0
-    dev: true
-
   /@babel/helper-compilation-targets/7.13.16_@babel+core@7.14.0:
     resolution: {integrity: sha512-3gmkYIrpqsLlieFwjkGgLaSHmhnvlAYzZLlYVjlW+QwI+1zE17kGxuJGmIqDQdYp56XdmGeD+Bswx0UTyG18xA==}
     peerDependencies:
@@ -400,7 +363,6 @@ packages:
       '@babel/helper-validator-option': 7.12.17
       browserslist: 4.16.6
       semver: 6.3.0
-    dev: false
 
   /@babel/helper-create-class-features-plugin/7.13.11_@babel+core@7.14.0:
     resolution: {integrity: sha512-ays0I7XYq9xbjCSvT+EvysLgfc3tOkwCULHjrnscGT3A9qD4sk3wXnJ3of0MAWsWGjdinFvajHU2smYuqXKMrw==}
@@ -498,21 +460,6 @@ packages:
     dependencies:
       '@babel/types': 7.14.1
 
-  /@babel/helper-module-transforms/7.13.14:
-    resolution: {integrity: sha512-QuU/OJ0iAOSIatyVZmfqB0lbkVP0kDRiKj34xy+QNsnVZi/PA6BoSoreeqnxxa9EHFAIL0R9XOaAR/G9WlIy5g==}
-    dependencies:
-      '@babel/helper-module-imports': 7.13.12
-      '@babel/helper-replace-supers': 7.13.12
-      '@babel/helper-simple-access': 7.13.12
-      '@babel/helper-split-export-declaration': 7.12.13
-      '@babel/helper-validator-identifier': 7.12.11
-      '@babel/template': 7.12.13
-      '@babel/traverse': 7.13.17
-      '@babel/types': 7.13.17
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /@babel/helper-module-transforms/7.14.0:
     resolution: {integrity: sha512-L40t9bxIuGOfpIGA3HNkJhU9qYrf4y5A5LUSw7rGMSn+pcG8dfJ0g6Zval6YJGd2nEjI7oP00fRdnhLKndx6bw==}
     dependencies:
@@ -526,7 +473,6 @@ packages:
       '@babel/types': 7.14.1
     transitivePeerDependencies:
       - supports-color
-    dev: false
 
   /@babel/helper-optimise-call-expression/7.12.13:
     resolution: {integrity: sha512-BdWQhoVJkp6nVjB7nkFWcn43dkprYauqtk++Py2eaf/GRDFm5BxRqEIZCiHlZUGAVmtwKcsVL1dC68WmzeFmiA==}
@@ -594,16 +540,6 @@ packages:
       - supports-color
     dev: false
 
-  /@babel/helpers/7.13.17:
-    resolution: {integrity: sha512-Eal4Gce4kGijo1/TGJdqp3WuhllaMLSrW6XcL0ulyUAQOuxHcCafZE8KHg9857gcTehsm/v7RcOx2+jp0Ryjsg==}
-    dependencies:
-      '@babel/template': 7.12.13
-      '@babel/traverse': 7.13.17
-      '@babel/types': 7.13.17
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /@babel/helpers/7.14.0:
     resolution: {integrity: sha512-+ufuXprtQ1D1iZTO/K9+EBRn+qPWMJjZSw/S0KlFrxCw4tkrzv9grgpDHkY9MeQTjTY8i2sp7Jep8DfU6tN9Mg==}
     dependencies:
@@ -612,7 +548,6 @@ packages:
       '@babel/types': 7.14.1
     transitivePeerDependencies:
       - supports-color
-    dev: false
 
   /@babel/highlight/7.14.0:
     resolution: {integrity: sha512-YSCOwxvTYEIMSGaBQb5kDDsCopDdiUGsqpatp3fOlI4+2HQSkTmEVWnVuySdAC5EWCqSWWTv0ib63RjR7dTBdg==}
@@ -1415,21 +1350,6 @@ packages:
       '@babel/code-frame': 7.12.13
       '@babel/parser': 7.14.1
       '@babel/types': 7.14.1
-
-  /@babel/traverse/7.13.17:
-    resolution: {integrity: sha512-BMnZn0R+X6ayqm3C3To7o1j7Q020gWdqdyP50KEoVqaCO2c/Im7sYZSmVgvefp8TTMQ+9CtwuBp0Z1CZ8V3Pvg==}
-    dependencies:
-      '@babel/code-frame': 7.12.13
-      '@babel/generator': 7.13.16
-      '@babel/helper-function-name': 7.12.13
-      '@babel/helper-split-export-declaration': 7.12.13
-      '@babel/parser': 7.13.16
-      '@babel/types': 7.13.17
-      debug: 4.3.1
-      globals: 11.12.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
 
   /@babel/traverse/7.14.0:
     resolution: {integrity: sha512-dZ/a371EE5XNhTHomvtuLTUyx6UEoJmYX+DT5zBCQN3McHemsuIaKKYqsc/fs26BEkHs/lBZy0J571LP5z9kQA==}
@@ -3597,8 +3517,8 @@ packages:
     engines: {node: '>=0.10'}
     dev: true
 
-  /dependency-graph/0.7.2:
-    resolution: {integrity: sha512-KqtH4/EZdtdfWX0p6MGP9jljvxSY6msy/pRUD4jgNwVpv3v1QmNLlsB3LDSSUg79BRVSn7jI1QPRtArGABovAQ==}
+  /dependency-graph/0.11.0:
+    resolution: {integrity: sha512-JeMq7fEshyepOWDfcfHK06N3MhyPhz++vtqWhMT5O9A3K42rdsEDpfdVqjaqaAhsw6a+ZqeDvQVtD0hFHQWrzg==}
     engines: {node: '>= 0.6.0'}
     dev: true
 
@@ -4232,14 +4152,6 @@ packages:
       universalify: 2.0.0
     dev: false
 
-  /fs-extra/4.0.2:
-    resolution: {integrity: sha1-+RcExT0bRh+JNFKwwwfZmXZHq2s=}
-    dependencies:
-      graceful-fs: 4.2.6
-      jsonfile: 4.0.0
-      universalify: 0.1.2
-    dev: true
-
   /fs-extra/9.1.0:
     resolution: {integrity: sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==}
     engines: {node: '>=10'}
@@ -4387,6 +4299,7 @@ packages:
 
   /graceful-fs/4.2.6:
     resolution: {integrity: sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==}
+    dev: false
 
   /growly/1.3.0:
     resolution: {integrity: sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=}
@@ -5522,12 +5435,6 @@ packages:
     dependencies:
       minimist: 1.2.5
 
-  /jsonfile/4.0.0:
-    resolution: {integrity: sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=}
-    optionalDependencies:
-      graceful-fs: 4.2.6
-    dev: true
-
   /jsonfile/6.1.0:
     resolution: {integrity: sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==}
     dependencies:
@@ -5759,7 +5666,6 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       yallist: 4.0.0
-    dev: false
 
   /magic-string/0.25.7:
     resolution: {integrity: sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==}
@@ -7163,7 +7069,6 @@ packages:
     hasBin: true
     dependencies:
       lru-cache: 6.0.0
-    dev: false
 
   /serialize-javascript/4.0.0:
     resolution: {integrity: sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==}
@@ -7865,6 +7770,12 @@ packages:
     hasBin: true
     dev: false
 
+  /typescript/4.2.4:
+    resolution: {integrity: sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==}
+    engines: {node: '>=4.2.0'}
+    hasBin: true
+    dev: true
+
   /uglify-js/3.13.5:
     resolution: {integrity: sha512-xtB8yEqIkn7zmOyS2zUNBsYCBRhDkvlNxMMY2smuJ/qA8NCHeQvKCF3i9Z4k8FJH4+PJvZRtMrPynfZ75+CSZw==}
     engines: {node: '>=0.8.0'}
@@ -7928,6 +7839,7 @@ packages:
   /universalify/0.1.2:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
     engines: {node: '>= 4.0.0'}
+    dev: false
 
   /universalify/2.0.0:
     resolution: {integrity: sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==}
@@ -8168,7 +8080,6 @@ packages:
 
   /yallist/4.0.0:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
-    dev: false
 
   /yaml/1.10.2:
     resolution: {integrity: sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==}
@@ -8216,6 +8127,8 @@ packages:
       y18n: 5.0.8
       yargs-parser: 20.2.7
 
-  /zone.js/0.10.3:
-    resolution: {integrity: sha512-LXVLVEq0NNOqK/fLJo3d0kfzd4sxwn2/h67/02pjCjfKDxgx1i9QqpvtHD8CrBnSSwMw5+dy11O7FRX5mkO7Cg==}
+  /zone.js/0.11.4:
+    resolution: {integrity: sha512-DDh2Ab+A/B+9mJyajPjHFPWfYU1H+pdun4wnnk0OcQTNjem1XQSZ2CDW+rfZEUDjv5M19SBqAkjZi0x5wuB5Qw==}
+    dependencies:
+      tslib: 2.2.0
     dev: true


### PR DESCRIPTION
Closes #514, #512

BREAKING CHANGE: there are 2 important changes:

  * deprecated CanPipe was removed, use AblePipe instead
  * library is compiled by Ivy and no longer support ViewEngine