### PR TITLE
feat(ability): adds posibility to define custom any action and any subject type instead of using `manage` and `all`

### DIFF
--- a/packages/casl-ability/spec/ability.spec.js
+++ b/packages/casl-ability/spec/ability.spec.js
@@ -76,6 +76,20 @@ describe('Ability', () => {
     expect(ability).to.allow('read')
   })
 
+  it('allows to define custom `anyAction` and `anySubjectType` options', () => {
+    ability = new Ability([{ action: '*', subject: '*' }], {
+      anyAction: '*',
+      anySubjectType: '*',
+    })
+
+    expect(ability.can('read', 'Post')).to.be.true
+    expect(ability.can('update', 'Post')).to.be.true
+    expect(ability.can('doAnythingWith', 'Post')).to.be.true
+    expect(ability.can('*', '*')).to.be.true
+    expect(ability.can('*', 'Post')).to.be.true
+    expect(ability.can('read', '*')).to.be.true
+  })
+
   describe('by default', () => {
     beforeEach(() => {
       ability = defineAbility((can, cannot) => {

--- a/packages/casl-ability/src/types.ts
+++ b/packages/casl-ability/src/types.ts
@@ -21,7 +21,7 @@ export type AbilityTupleType<
   U extends SubjectType = SubjectType
 > = [T, U];
 export type AbilityTypes = string | AbilityTupleType;
-export type Normalize<T extends Abilities> = T extends AbilityTuple ? T : [T, 'all'];
+export type Normalize<T extends Abilities> = T extends AbilityTuple ? T : [T, string];
 
 export type IfString<T, U> = T extends string ? U : never;
 export type AbilityParameters<


### PR DESCRIPTION
Fixes #527

Contains 2 minor breaking changes which should not affect anybody:
1. `createAliasResolver` validates alias map in any env now, can be changed by specifying `skipValidation`  option. Previously, it did validation in non production envs only
2. `detectSubjectType` option should not handle undefined subject anymore, as it's handled by library internally