### PR TITLE
chore: add repository directory for all packages.json

### DIFF
--- a/packages/casl-ability/package.json
+++ b/packages/casl-ability/package.json
@@ -21,7 +21,8 @@
   "sideEffects": false,
   "repository": {
     "type": "git",
-    "url": "https://github.com/stalniy/casl.git"
+    "url": "https://github.com/stalniy/casl.git",
+    "directory": "packages/casl-ability"
   },
   "homepage": "https://casl.js.org",
   "publishConfig": {

--- a/packages/casl-angular/package.json
+++ b/packages/casl-angular/package.json
@@ -14,7 +14,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/stalniy/casl.git"
+    "url": "https://github.com/stalniy/casl.git",
+    "directory": "packages/casl-angular"
   },
   "homepage": "https://casl.js.org",
   "publishConfig": {

--- a/packages/casl-aurelia/package.json
+++ b/packages/casl-aurelia/package.json
@@ -14,7 +14,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/stalniy/casl.git"
+    "url": "https://github.com/stalniy/casl.git",
+    "directory": "packages/casl-aurelia"
   },
   "homepage": "https://casl.js.org",
   "publishConfig": {

--- a/packages/casl-mongoose/package.json
+++ b/packages/casl-mongoose/package.json
@@ -13,7 +13,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/stalniy/casl.git"
+    "url": "https://github.com/stalniy/casl.git",
+    "directory": "packages/casl-mongoose"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/casl-prisma/package.json
+++ b/packages/casl-prisma/package.json
@@ -13,7 +13,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/stalniy/casl.git"
+    "url": "https://github.com/stalniy/casl.git",
+    "directory": "packages/casl-prisma"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/casl-react/package.json
+++ b/packages/casl-react/package.json
@@ -14,7 +14,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/stalniy/casl.git"
+    "url": "https://github.com/stalniy/casl.git",
+    "directory": "packages/casl-react"
   },
   "homepage": "https://casl.js.org",
   "publishConfig": {

--- a/packages/casl-vue/package.json
+++ b/packages/casl-vue/package.json
@@ -14,7 +14,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/stalniy/casl.git"
+    "url": "https://github.com/stalniy/casl.git",
+    "directory": "packages/casl-vue"
   },
   "homepage": "https://casl.js.org",
   "publishConfig": {


### PR DESCRIPTION
> If the package.json for your package is not in the root directory (for example if it is part of a monorepo), you can specify the directory in which it lives:
> ```json
> "repository": {
>   "type" : "git",
>   "url" : "https://github.com/facebook/react.git",
>   "directory": "packages/react-dom"
> }
> ```
> — https://docs.npmjs.com/cli/v6/configuring-npm/package-json#repository

I use a lot https://njt.vercel.app/ to jump to different packages information,
and with this PR we can know exactly what package in what folder lives

Made the changes with a script to make it easier 🙂

https://gist.github.com/iamandrewluca/5cc85b56a595056f0099d04ed6dd8a79