### PR TITLE
Pin war notification to the header

### DIFF
--- a/docs-src/src/components/App.js
+++ b/docs-src/src/components/App.js
@@ -117,12 +117,8 @@ export default class App extends LitElement {
 
     const { body } = this._route;
     const sidebar = body.sidebar ? cache(body.sidebar) : '';
-    const stopWar = `
-      Stop war in Ukraine. <a href="https://dearrussian.wtf" target="_blank">All truth about Russia invasion</a>
-    `;
 
     return html`
-      <app-notification class="stop-war" .message="${stopWar}"></app-notification>
       <menu-drawer ?disabled="${!this._isMobile}">
         <div slot="menu">${this._renderDrawerMenu(sidebar)}</div>
         <app-root

--- a/docs-src/src/components/AppHeader.js
+++ b/docs-src/src/components/AppHeader.js
@@ -73,13 +73,19 @@ export default class Header extends LitElement {
 
   render() {
     return html`
-      <header class="container">
-        ${this._renderMenuToggler()}
-        <div>
-          <app-link to="home" class="logo">${t('name')}</app-link>
-          <versions-select></versions-select>
+      <header>
+        <div class="header-notification">
+          <p>Stop war in 🇺🇦 Ukraine.</p>
+          <a href="https://dearrussian.wtf" target="_blank">All truth about Russia invasion</a>
         </div>
-        ${this._renderControls()}
+        <div class="header container">
+          ${this._renderMenuToggler()}
+          <div>
+            <app-link to="home" class="logo">${t('name')}</app-link>
+            <versions-select></versions-select>
+          </div>
+          ${this._renderControls()}
+        </div>
       </header>
       <!-- <app-lang-picker></app-lang-picker> -->
     `;
@@ -98,12 +104,26 @@ Header.styles = [
       text-decoration: none;
     }
 
-    header {
+    .header {
       position: relative;
       display: flex;
       align-items: center;
       justify-content: center;
       padding: 0 10px 0 1rem;
+    }
+
+    .header-notification {
+      background: rgba(84, 172, 237, 0.18);
+      display: flex;
+      flex-wrap: wrap;
+      flex-direction: column;
+      align-items: center;
+      padding: 10px;
+      gap: 0;
+    }
+
+    .header-notification p {
+      margin: 0;
     }
 
     .logo {
@@ -156,8 +176,14 @@ Header.styles = [
     }
 
     @media (min-width: 768px) {
-      header {
+      .header {
         justify-content: space-between;
+      }
+
+      .header-notification {
+        flex-direction: row;
+        justify-content: center;
+        gap: 5px;
       }
 
       .logo {


### PR DESCRIPTION
Hi,


The current version of the documentation which contains "Stop war in Ukraine" notification blocks the header menu items. So, I decided to fix this issue and pin the notification to the top of the header of the page.  

Examples:

<details>
  <summary>Before mobile version</summary>
  
![casl js org_v5_en_(iPhone 12 Pro)](https://user-images.githubusercontent.com/8645216/162939002-f8dada7a-cbb6-4ff5-8d81-1f86a4ca4131.png)
  
</details>

<details>
  <summary>After mobile version</summary>
  
![localhost_8080_en_cookbook_intro(iPhone 12 Pro)](https://user-images.githubusercontent.com/8645216/162939127-e6902039-96cd-4c1b-886b-901d91e8a1d0.png)
  
</details>

<details>
  <summary>Before desktop</summary>
  
<img width="1440" alt="Screenshot 2022-04-12 at 13 13 23" src="https://user-images.githubusercontent.com/8645216/162939307-1a41e9a6-0d50-4e4f-bf1a-278918f93849.png">
  
</details>


<details>
  <summary>After desktop</summary>

<img width="1440" alt="Screenshot 2022-04-12 at 13 12 40" src="https://user-images.githubusercontent.com/8645216/162939341-c3d049ed-5d65-4d9c-be91-15c83452be64.png">
  
</details>





