### PR TITLE
Replace `StatelessComponent` in the favor of `FunctionComponent`

### DIFF
--- a/packages/casl-react/src/factory.ts
+++ b/packages/casl-react/src/factory.ts
@@ -1,4 +1,4 @@
-import { createElement as h, ComponentClass, Consumer, StatelessComponent } from 'react';
+import { createElement as h, ComponentClass, Consumer, FunctionComponent } from 'react';
 import { AnyAbility } from '@casl/ability';
 import { Can, BoundCanProps } from './Can';
 
@@ -14,7 +14,7 @@ export function createCanBoundTo<T extends AnyAbility>(ability: T): BoundCanClas
 
 export function createContextualCan<T extends AnyAbility>(
   Getter: Consumer<T>
-): StatelessComponent<BoundCanProps<T>> {
+): FunctionComponent<BoundCanProps<T>> {
   return (props: BoundCanProps<T>) => h(Getter, null, (ability: T) => h(Can, {
     ability,
     ...props,


### PR DESCRIPTION
React 18 had removed `StatelessComponent`, so the I think it a good time to replace with `FunctionComponent`