### PR TITLE
fix: improved AbilityTuple

### DIFF
--- a/packages/casl-prisma/spec/PrismaAbility.spec.ts
+++ b/packages/casl-prisma/spec/PrismaAbility.spec.ts
@@ -14,6 +14,7 @@ describe('PrismaAbility', () => {
     })
     const ability = build()
 
+    expect(ability.can('read', 'all')).toBe(false)
     expect(ability.can('read', subject('Post', { authorId: 1 } as Post))).toBe(false)
     expect(ability.can('read', subject('Post', { authorId: 2 } as Post))).toBe(false)
     expect(ability.can('read', subject('Post', { authorId: 3 } as Post))).toBe(true)
@@ -43,8 +44,11 @@ describe('PrismaAbility', () => {
           conditions: {
             // @ts-expect-error unknown model field in conditions
             unknown: 1,
-
           }
+        },
+        {
+          action: 'read',
+          subject: 'all'
         }
       ])).toBeInstanceOf(AppAbility)
     })
@@ -73,6 +77,7 @@ describe('PrismaAbility', () => {
           }
         }
       })
+      can('delete', 'all')
     })
 
     it('uses Prisma types when building `PrismaQuery<TModel>` type', () => {

--- a/packages/casl-prisma/src/PrismaAbility.ts
+++ b/packages/casl-prisma/src/PrismaAbility.ts
@@ -2,11 +2,16 @@ import { Prisma } from '@prisma/client';
 import { AbilityOptions, AbilityTuple, fieldPatternMatcher, PureAbility, RawRuleFrom } from '@casl/ability';
 import { PrismaQuery, prismaQuery } from './prisma/PrismaQuery';
 
+type ExtendedAbilityTuple<T extends AbilityTuple> = [T[0], 'all' | T[1]];
+
 export class PrismaAbility<
-  A extends AbilityTuple = [string, 'all' | Prisma.ModelName],
+  A extends AbilityTuple = [string, Prisma.ModelName],
   C extends PrismaQuery = PrismaQuery
-> extends PureAbility<A, C> {
-  constructor(rules?: RawRuleFrom<A, C>[], options?: AbilityOptions<A, C>) {
+> extends PureAbility<ExtendedAbilityTuple<A>, C> {
+  constructor(
+    rules?: RawRuleFrom<ExtendedAbilityTuple<A>, C>[],
+    options?: AbilityOptions<ExtendedAbilityTuple<A>, C>
+  ) {
     super(rules, {
       conditionsMatcher: prismaQuery,
       fieldMatcher: fieldPatternMatcher,

--- a/packages/casl-prisma/src/PrismaAbility.ts
+++ b/packages/casl-prisma/src/PrismaAbility.ts
@@ -3,7 +3,7 @@ import { AbilityOptions, AbilityTuple, fieldPatternMatcher, PureAbility, RawRule
 import { PrismaQuery, prismaQuery } from './prisma/PrismaQuery';
 
 export class PrismaAbility<
-  A extends AbilityTuple = [string, Prisma.ModelName],
+  A extends AbilityTuple = [string, 'all' | Prisma.ModelName],
   C extends PrismaQuery = PrismaQuery
 > extends PureAbility<A, C> {
   constructor(rules?: RawRuleFrom<A, C>[], options?: AbilityOptions<A, C>) {


### PR DESCRIPTION
https://github.com/stalniy/casl/pull/615 forces the user to define their AppAbility like `PrismaAbility<[string, 'all' | Subjects<{ ... }>]>`. This fix makes sure the user does not have to provide the 'all' union and can define it like `PrismaAbility<[string, Subjects<{ ... }>]>`.