### PR TITLE
docs(guide): update sample for raw rule type shape

### DIFF
--- a/docs-src/src/content/pages/guide/define-rules/en.md
+++ b/docs-src/src/content/pages/guide/define-rules/en.md
@@ -171,7 +171,7 @@ The simplified version (without generics) of raw rule shape in [TypeScript](http
 ```ts
 interface RawRule {
   action: string | string[]
-  subject?: string | string[]
+  subject: string | string[]
   /** an array of fields to which user has (or not) access */
   fields?: string[]
   /** an object of conditions which restricts the rule scope */


### PR DESCRIPTION
code example fixed
- changed the `subject` type shape in the type definition of Raw Rule from optional to required.