### PR TITLE
chore(deps): update peer dependency react to v18

### DIFF
--- a/packages/casl-react/package.json
+++ b/packages/casl-react/package.json
@@ -41,7 +41,7 @@
   "license": "MIT",
   "peerDependencies": {
     "@casl/ability": "^3.0.0 || ^4.0.0 || ^5.1.0",
-    "react": "^15.0.0 || ^16.0.0 || ^17.0.0"
+    "react": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0"
   },
   "devDependencies": {
     "@casl/ability": "^5.1.0",


### PR DESCRIPTION
fixed `@casl/react` cant be installed with react@18