### PR TITLE
Adapt Mongoose typings

### DIFF
--- a/packages/casl-mongoose/package.json
+++ b/packages/casl-mongoose/package.json
@@ -40,7 +40,7 @@
   "license": "MIT",
   "peerDependencies": {
     "@casl/ability": "^3.0.0 || ^4.0.0 || ^5.1.0",
-    "mongoose": "^6.0.0"
+    "mongoose": "^6.0.13"
   },
   "devDependencies": {
     "@casl/ability": "^5.1.0",
@@ -48,7 +48,7 @@
     "@types/jest": "^26.0.22",
     "chai": "^4.1.0",
     "chai-spies": "^1.0.0",
-    "mongoose": "^6.0.0"
+    "mongoose": "^6.0.13"
   },
   "files": [
     "dist",

--- a/packages/casl-mongoose/spec/accessible_fields.spec.ts
+++ b/packages/casl-mongoose/spec/accessible_fields.spec.ts
@@ -1,13 +1,16 @@
 import { defineAbility, Ability } from '@casl/ability'
 import mongoose from 'mongoose'
-import { AccessibleFieldsModel, accessibleFieldsPlugin, AccessibleFieldsDocument } from '../src'
+import { AccessibleFieldsModel, accessibleFieldsPlugin } from '../src'
 
 describe('Accessible fields plugin', () => {
-  interface Post extends AccessibleFieldsDocument {
+  interface Post {
     title: string;
     state: string;
   }
-  let PostSchema: mongoose.Schema<Post>
+
+  type PostModel = AccessibleFieldsModel<Post>
+
+  let PostSchema: mongoose.Schema<Post, PostModel>
 
   beforeEach(() => {
     PostSchema = new mongoose.Schema<Post>({
@@ -21,7 +24,7 @@ describe('Accessible fields plugin', () => {
   })
 
   it('adds static and instace `accessibleFieldsBy` method', () => {
-    const Post = mongoose.model<Post, AccessibleFieldsModel<Post>>(
+    const Post = mongoose.model<Post, PostModel>(
       'Post',
       PostSchema.plugin(accessibleFieldsPlugin)
     )

--- a/packages/casl-mongoose/spec/accessible_fields.spec.ts
+++ b/packages/casl-mongoose/spec/accessible_fields.spec.ts
@@ -1,6 +1,6 @@
 import { defineAbility, Ability } from '@casl/ability'
 import mongoose from 'mongoose'
-import { AccessibleFieldsModel, accessibleFieldsPlugin } from '../src'
+import { accessibleFieldsPlugin, AccessibleFieldsModel } from '../src'
 
 describe('Accessible fields plugin', () => {
   interface Post {
@@ -9,7 +9,6 @@ describe('Accessible fields plugin', () => {
   }
 
   type PostModel = AccessibleFieldsModel<Post>
-
   let PostSchema: mongoose.Schema<Post, PostModel>
 
   beforeEach(() => {
@@ -35,12 +34,12 @@ describe('Accessible fields plugin', () => {
   })
 
   describe('`accessibleFieldsBy` method', () => {
-    let Post: AccessibleFieldsModel<Post>
+    let Post: PostModel
 
     describe('by default', () => {
       beforeEach(() => {
         PostSchema.plugin(accessibleFieldsPlugin)
-        Post = mongoose.model<Post, AccessibleFieldsModel<Post>>('Post', PostSchema)
+        Post = mongoose.model<Post, PostModel>('Post', PostSchema)
       })
 
       it('returns empty array for empty `Ability` instance', () => {
@@ -89,28 +88,28 @@ describe('Accessible fields plugin', () => {
 
       it('returns fields provided in `only` option specified as string', () => {
         PostSchema.plugin(accessibleFieldsPlugin, { only: 'title' })
-        Post = mongoose.model<Post, AccessibleFieldsModel<Post>>('Post', PostSchema)
+        Post = mongoose.model<Post, PostModel>('Post', PostSchema)
 
         expect(Post.accessibleFieldsBy(ability)).toEqual(['title'])
       })
 
       it('returns fields provided in `only` option specified as array', () => {
         PostSchema.plugin(accessibleFieldsPlugin, { only: ['title', 'state'] })
-        Post = mongoose.model<Post, AccessibleFieldsModel<Post>>('Post', PostSchema)
+        Post = mongoose.model<Post, PostModel>('Post', PostSchema)
 
         expect(Post.accessibleFieldsBy(ability)).toEqual(['title', 'state'])
       })
 
       it('returns all fields except one specified in `except` option as string', () => {
         PostSchema.plugin(accessibleFieldsPlugin, { except: '_id' })
-        Post = mongoose.model<Post, AccessibleFieldsModel<Post>>('Post', PostSchema)
+        Post = mongoose.model<Post, PostModel>('Post', PostSchema)
 
         expect(Post.accessibleFieldsBy(ability)).toEqual(['title', 'state', '__v'])
       })
 
       it('returns all fields except specified in `except` option as array', () => {
         PostSchema.plugin(accessibleFieldsPlugin, { except: ['_id', '__v'] })
-        Post = mongoose.model<Post, AccessibleFieldsModel<Post>>('Post', PostSchema)
+        Post = mongoose.model<Post, PostModel>('Post', PostSchema)
 
         expect(Post.accessibleFieldsBy(ability)).toEqual(['title', 'state'])
       })

--- a/packages/casl-mongoose/spec/accessible_records.spec.ts
+++ b/packages/casl-mongoose/spec/accessible_records.spec.ts
@@ -3,7 +3,7 @@ import mongoose from 'mongoose'
 import { AccessibleRecordModel, accessibleRecordsPlugin, toMongoQuery } from '../src'
 
 describe('Accessible Records Plugin', () => {
-  interface Post extends mongoose.Document {
+  interface Post {
     title: string;
     state: string;
   }
@@ -79,8 +79,19 @@ describe('Accessible Records Plugin', () => {
       Post.accessibleBy(ability).where({ title: /test/ }).accessibleBy(ability, 'delete')
     })
 
+    it('has proper typing for `accessibleBy` methods', () => {
+      let expectedQueryType: mongoose.Query<mongoose.HydratedDocument<Post>[], any>
+      expectedQueryType = Post.find()
+      expectedQueryType = Post.find().accessibleBy(ability)
+      expectedQueryType = Post.find().accessibleBy(ability).accessibleBy(ability, 'update')
+      expectedQueryType = Post.accessibleBy(ability).where({ title: /test/ }).accessibleBy(ability, 'delete')
+      expectedQueryType = Post.accessibleBy(ability).find()
+      expectedQueryType = Post.accessibleBy(ability).accessibleBy(ability, 'update').find()
+      expect(expectedQueryType).not.toBeUndefined()
+    })
+
     describe('when ability disallow to perform an action', () => {
-      let query: mongoose.QueryWithHelpers<Post, Post>
+      let query: mongoose.QueryWithHelpers<Post, Post, any, any>
 
       beforeEach(() => {
         query = Post.find().accessibleBy(ability, 'notAllowedAction')
@@ -89,7 +100,7 @@ describe('Accessible Records Plugin', () => {
       it('throws `ForbiddenError` for collection request', async () => {
         await query.exec()
           .then(() => fail('should not execute'))
-          .catch((error) => {
+          .catch((error: any) => {
             expect(error).toBeInstanceOf(ForbiddenError)
             expect(error.message).toMatch(/cannot execute/i)
           })
@@ -98,7 +109,7 @@ describe('Accessible Records Plugin', () => {
       it('throws `ForbiddenError` when `find` is called', async () => {
         await query.find()
           .then(() => fail('should not execute'))
-          .catch((error) => {
+          .catch((error: any) => {
             expect(error).toBeInstanceOf(ForbiddenError)
             expect(error.message).toMatch(/cannot execute/i)
           })
@@ -107,7 +118,7 @@ describe('Accessible Records Plugin', () => {
       it('throws `ForbiddenError` when callback is passed to `exec`', async () => {
         await wrapInPromise(cb => query.exec(cb))
           .then(() => fail('should not execute'))
-          .catch((error) => {
+          .catch((error: any) => {
             expect(error).toBeInstanceOf(ForbiddenError)
             expect(error.message).toMatch(/cannot execute/i)
           })
@@ -116,7 +127,7 @@ describe('Accessible Records Plugin', () => {
       it('throws `ForbiddenError` for item request', async () => {
         await query.findOne().exec()
           .then(() => fail('should not execute'))
-          .catch((error) => {
+          .catch((error: any) => {
             expect(error).toBeInstanceOf(ForbiddenError)
             expect(error.message).toMatch(/cannot execute/i)
           })
@@ -125,7 +136,7 @@ describe('Accessible Records Plugin', () => {
       it('throws `ForbiddenError` when `findOne` is called', async () => {
         await query.findOne()
           .then(() => fail('should not execute'))
-          .catch((error) => {
+          .catch((error: any) => {
             expect(error).toBeInstanceOf(ForbiddenError)
             expect(error.message).toMatch(/cannot execute/i)
           })
@@ -134,7 +145,7 @@ describe('Accessible Records Plugin', () => {
       it('throws `ForbiddenError` for item request when callback is passed to `exec`', async () => {
         await wrapInPromise(cb => query.findOne().exec(cb))
           .then(() => fail('should not execute'))
-          .catch((error) => {
+          .catch((error: any) => {
             expect(error).toBeInstanceOf(ForbiddenError)
             expect(error.message).toMatch(/cannot execute/i)
           })
@@ -143,7 +154,7 @@ describe('Accessible Records Plugin', () => {
       it('throws `ForbiddenError` for count request', async () => {
         await query.count()
           .then(() => fail('should not execute'))
-          .catch((error) => {
+          .catch((error: any) => {
             expect(error).toBeInstanceOf(ForbiddenError)
             expect(error.message).toMatch(/cannot execute/i)
           })
@@ -152,7 +163,7 @@ describe('Accessible Records Plugin', () => {
       it('throws `ForbiddenError` for count request', async () => {
         await query.count()
           .then(() => fail('should not execute'))
-          .catch((error) => {
+          .catch((error: any) => {
             expect(error).toBeInstanceOf(ForbiddenError)
             expect(error.message).toMatch(/cannot execute/i)
           })
@@ -161,7 +172,7 @@ describe('Accessible Records Plugin', () => {
       it('throws `ForbiddenError` for `countDocuments` request', async () => {
         await query.countDocuments()
           .then(() => fail('should not execute'))
-          .catch((error) => {
+          .catch((error: any) => {
             expect(error).toBeInstanceOf(ForbiddenError)
             expect(error.message).toMatch(/cannot execute/i)
           })
@@ -170,7 +181,7 @@ describe('Accessible Records Plugin', () => {
       it('throws `ForbiddenError` for `countDocuments` request', async () => {
         await query.estimatedDocumentCount()
           .then(() => fail('should not execute'))
-          .catch((error) => {
+          .catch((error: any) => {
             expect(error).toBeInstanceOf(ForbiddenError)
             expect(error.message).toMatch(/cannot execute/i)
           })

--- a/packages/casl-mongoose/src/accessible_fields.ts
+++ b/packages/casl-mongoose/src/accessible_fields.ts
@@ -63,7 +63,7 @@ function modelFieldsGetter() {
 export function accessibleFieldsPlugin(
   schema: Schema<any>,
   rawOptions?: Partial<AccessibleFieldsOptions>
-) {
+): void {
   const options = { getFields: getSchemaPaths, ...rawOptions };
   const fieldsFrom = modelFieldsGetter();
   type ModelOrDoc = Model<AccessibleFieldsDocument> | AccessibleFieldsDocument;

--- a/packages/casl-mongoose/src/accessible_fields.ts
+++ b/packages/casl-mongoose/src/accessible_fields.ts
@@ -32,16 +32,18 @@ export interface AccessibleFieldsModel<
   TQueryHelpers = {},
   TMethods = {},
   TVirtuals = {}
-> extends Model<T, TQueryHelpers, TMethods & AccessibleFieldDocumentMethods, TVirtuals> {
+> extends Model<T, TQueryHelpers, TMethods & AccessibleFieldDocumentMethods<T>, TVirtuals> {
   accessibleFieldsBy: GetAccessibleFields<T>
 }
 
-export interface AccessibleFieldDocumentMethods {
-  accessibleFieldsBy: GetAccessibleFields<Document>
+export interface AccessibleFieldDocumentMethods<T = Document> {
+  accessibleFieldsBy: GetAccessibleFields<T>
 }
 
-/** @deprecated Mongoose recommends against `extends Document`, prefer to use `AccessibleFieldsModel` instead.
- * See here: https://mongoosejs.com/docs/typescript.html#using-extends-document */
+/**
+ * @deprecated Mongoose recommends against `extends Document`, prefer to use `AccessibleFieldsModel` instead.
+ * See here: https://mongoosejs.com/docs/typescript.html#using-extends-document
+ */
 export interface AccessibleFieldsDocument extends Document, AccessibleFieldDocumentMethods {}
 
 function modelFieldsGetter() {

--- a/packages/casl-mongoose/src/accessible_fields.ts
+++ b/packages/casl-mongoose/src/accessible_fields.ts
@@ -21,19 +21,28 @@ function fieldsOf(schema: Schema<Document>, options: Partial<AccessibleFieldsOpt
   return fields.filter(field => excludedFields.indexOf(field) === -1);
 }
 
-type GetAccessibleFields<T extends AccessibleFieldsDocument> = <U extends AnyMongoAbility>(
+type GetAccessibleFields<T> = <U extends AnyMongoAbility>(
   this: Model<T> | T,
   ability: U,
   action?: Normalize<Generics<U>['abilities']>[0]
 ) => string[];
 
-export interface AccessibleFieldsModel<T extends AccessibleFieldsDocument> extends Model<T> {
+export interface AccessibleFieldsModel<
+  T,
+  TQueryHelpers = {},
+  TMethods = {},
+  TVirtuals = {}
+> extends Model<T, TQueryHelpers, TMethods & AccessibleFieldDocumentMethods, TVirtuals> {
   accessibleFieldsBy: GetAccessibleFields<T>
 }
 
-export interface AccessibleFieldsDocument extends Document {
-  accessibleFieldsBy: GetAccessibleFields<AccessibleFieldsDocument>
+export interface AccessibleFieldDocumentMethods {
+  accessibleFieldsBy: GetAccessibleFields<Document>
 }
+
+/** @deprecated Mongoose recommends against `extends Document`, prefer to use `AccessibleFieldsModel` instead.
+ * See here: https://mongoosejs.com/docs/typescript.html#using-extends-document */
+export interface AccessibleFieldsDocument extends Document, AccessibleFieldDocumentMethods {}
 
 function modelFieldsGetter() {
   let fieldsFrom: PermittedFieldsOptions<AnyMongoAbility>['fieldsFrom'];

--- a/packages/casl-mongoose/src/accessible_records.ts
+++ b/packages/casl-mongoose/src/accessible_records.ts
@@ -79,7 +79,8 @@ export interface AccessibleRecordModel<
   HydratedDocument<T, TMethods, TVirtuals>,
   TQueryHelpers,
   TMethods,
-  TVirtuals>
+  TVirtuals
+  >
 }
 
 export function accessibleRecordsPlugin(schema: Schema<any, any, any, any>) {

--- a/packages/casl-mongoose/src/accessible_records.ts
+++ b/packages/casl-mongoose/src/accessible_records.ts
@@ -52,7 +52,11 @@ function accessibleBy<T extends AnyMongoAbility>(
 type GetAccessibleRecords<T, TQueryHelpers, TMethods, TVirtuals> = <U extends AnyMongoAbility>(
   ability: U,
   action?: Normalize<Generics<U>['abilities']>[0]
-) => QueryWithHelpers<Array<T>, T, QueryHelpers<T, TQueryHelpers, TMethods, TVirtuals>>;
+) => QueryWithHelpers<
+Array<T>,
+T,
+AccessibleRecordQueryHelpers<T, TQueryHelpers, TMethods, TVirtuals>
+>;
 
 export type AccessibleRecordQueryHelpers<T, TQueryHelpers = {}, TMethods = {}, TVirtuals = {}> = {
   accessibleBy: GetAccessibleRecords<

--- a/packages/casl-mongoose/src/accessible_records.ts
+++ b/packages/casl-mongoose/src/accessible_records.ts
@@ -54,12 +54,13 @@ type GetAccessibleRecords<T, TQueryHelpers, TMethods, TVirtuals> = <U extends An
   action?: Normalize<Generics<U>['abilities']>[0]
 ) => QueryWithHelpers<Array<T>, T, QueryHelpers<T, TQueryHelpers, TMethods, TVirtuals>>;
 
-type QueryHelpers<T, TQueryHelpers = {}, TMethods = {}, TVirtuals = {}> = {
+export type AccessibleRecordQueryHelpers<T, TQueryHelpers = {}, TMethods = {}, TVirtuals = {}> = {
   accessibleBy: GetAccessibleRecords<
   HydratedDocument<T, TMethods, TVirtuals>,
   TQueryHelpers,
   TMethods,
-  TVirtuals>
+  TVirtuals
+  >
 };
 export interface AccessibleRecordModel<
   T,
@@ -67,7 +68,7 @@ export interface AccessibleRecordModel<
   TMethods = {},
   TVirtuals = {}
 > extends Model<T,
-  TQueryHelpers & QueryHelpers<T, TQueryHelpers, TMethods, TVirtuals>,
+  TQueryHelpers & AccessibleRecordQueryHelpers<T, TQueryHelpers, TMethods, TVirtuals>,
   TMethods,
   TVirtuals> {
   accessibleBy: GetAccessibleRecords<

--- a/packages/casl-mongoose/src/accessible_records.ts
+++ b/packages/casl-mongoose/src/accessible_records.ts
@@ -83,7 +83,7 @@ export interface AccessibleRecordModel<
   >
 }
 
-export function accessibleRecordsPlugin(schema: Schema<any, any, any, any>) {
-  schema.query.accessibleBy = accessibleBy;
+export function accessibleRecordsPlugin(schema: Schema<any>): void {
+  (schema.query as Record<string, unknown>).accessibleBy = accessibleBy;
   schema.statics.accessibleBy = accessibleBy;
 }

--- a/packages/casl-mongoose/src/index.ts
+++ b/packages/casl-mongoose/src/index.ts
@@ -1,8 +1,12 @@
-import { AccessibleFieldsModel, AccessibleFieldsDocument } from './accessible_fields';
+import { AccessibleFieldsModel } from './accessible_fields';
 import { AccessibleRecordModel } from './accessible_records';
 
-export type AccessibleModel<T extends AccessibleFieldsDocument> =
-  AccessibleRecordModel<T> & AccessibleFieldsModel<T>;
+export type AccessibleModel<T,
+  TQueryHelpers = {},
+  TMethods = {},
+  TVirtuals = {}> =
+  AccessibleRecordModel<T, TQueryHelpers, TMethods, TVirtuals> &
+  AccessibleFieldsModel<T, TQueryHelpers, TMethods, TVirtuals>;
 
 export * from './accessible_records';
 export * from './accessible_fields';

--- a/packages/casl-mongoose/src/index.ts
+++ b/packages/casl-mongoose/src/index.ts
@@ -12,7 +12,7 @@ export interface AccessibleModel<
   AccessibleFieldsModel<T, TQueryHelpers & AccessibleRecordQueryHelpers<
   T,
   TQueryHelpers,
-  TMethods,
+  TMethods & AccessibleFieldDocumentMethods<T>,
   TVirtuals
   >, TMethods, TVirtuals>
 {}

--- a/packages/casl-mongoose/src/index.ts
+++ b/packages/casl-mongoose/src/index.ts
@@ -1,13 +1,28 @@
-import { AccessibleFieldsModel } from './accessible_fields';
-import { AccessibleRecordModel } from './accessible_records';
+import { AccessibleFieldDocumentMethods, AccessibleFieldsModel } from './accessible_fields';
+import { AccessibleRecordModel, AccessibleRecordQueryHelpers } from './accessible_records';
 
-export type AccessibleModel<T,
-  TQueryHelpers = {},
-  TMethods = {},
-  TVirtuals = {}> =
-  AccessibleRecordModel<T, TQueryHelpers, TMethods, TVirtuals> &
-  AccessibleFieldsModel<T, TQueryHelpers, TMethods, TVirtuals>;
+export interface AccessibleModel<
+  T,
+  TQueryHelpers = unknown,
+  TMethods = unknown,
+  TVirtuals = unknown
+  >
+  extends
+  AccessibleRecordModel<T, TQueryHelpers, TMethods & AccessibleFieldDocumentMethods<T>, TVirtuals>,
+  AccessibleFieldsModel<T, TQueryHelpers & AccessibleRecordQueryHelpers<
+  T,
+  TQueryHelpers,
+  TMethods,
+  TVirtuals
+  >, TMethods, TVirtuals>
+{}
 
-export * from './accessible_records';
-export * from './accessible_fields';
-export * from './mongo';
+export { accessibleRecordsPlugin } from './accessible_records';
+export type { AccessibleRecordModel } from './accessible_records';
+export { getSchemaPaths, accessibleFieldsPlugin } from './accessible_fields';
+export type {
+  AccessibleFieldsModel,
+  AccessibleFieldsDocument,
+  AccessibleFieldsOptions
+} from './accessible_fields';
+export { toMongoQuery } from './mongo';

--- a/packages/casl-mongoose/src/mongo.ts
+++ b/packages/casl-mongoose/src/mongo.ts
@@ -1,5 +1,5 @@
 import { AnyMongoAbility } from '@casl/ability';
-import { rulesToQuery } from '@casl/ability/extra';
+import { AbilityQuery, rulesToQuery } from '@casl/ability/extra';
 
 function convertToMongoQuery(rule: AnyMongoAbility['rules'][number]) {
   const conditions = rule.conditions!;
@@ -10,6 +10,6 @@ export function toMongoQuery<T extends AnyMongoAbility>(
   ability: T,
   subjectType: Parameters<T['rulesFor']>[1],
   action: Parameters<T['rulesFor']>[0] = 'read'
-) {
+): AbilityQuery | null {
   return rulesToQuery(ability, action, subjectType, convertToMongoQuery);
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -98,14 +98,14 @@ importers:
       '@types/jest': ^26.0.22
       chai: ^4.1.0
       chai-spies: ^1.0.0
-      mongoose: ^6.0.0
+      mongoose: ^6.0.13
     devDependencies:
       '@casl/ability': link:../casl-ability
       '@casl/dx': link:../dx
       '@types/jest': 26.0.22
       chai: 4.3.4
       chai-spies: 1.0.0_chai@4.3.4
-      mongoose: 6.0.10
+      mongoose: 6.4.3
 
   packages/casl-prisma:
     specifiers:
@@ -4801,8 +4801,8 @@ packages:
     dependencies:
       node-int64: 0.4.0
 
-  /bson/4.5.3:
-    resolution: {integrity: sha512-qVX7LX79Mtj7B3NPLzCfBiCP6RAsjiV8N63DjlaVVpZW+PFoDTxQ4SeDbSpcqgE6mXksM5CAwZnXxxxn/XwC0g==}
+  /bson/4.6.4:
+    resolution: {integrity: sha512-TdQ3FzguAu5HKPPlr0kYQCyrYUYh8tFM+CMTpxjNzVzxeiJY00Rtuj3LXLHSgiGvmaWlZ8PE+4KyM2thqE38pQ==}
     engines: {node: '>=6.9.0'}
     dependencies:
       buffer: 5.7.1
@@ -8319,8 +8319,8 @@ packages:
       object.assign: 4.1.2
     dev: false
 
-  /kareem/2.3.2:
-    resolution: {integrity: sha512-STHz9P7X2L4Kwn72fA4rGyqyXdmrMSdxqHx9IXon/FXluXieaFA6KJ2upcHAHxQPQ0LeM/OjLrhFxifHewOALQ==}
+  /kareem/2.4.1:
+    resolution: {integrity: sha512-aJ9opVoXroQUPfovYP5kaj2lM7Jn02Gw13bL0lg9v0V7SaUc0qavPs0Eue7d2DcC3NjqI6QAUElXNsuZSeM+EA==}
     dev: true
 
   /karma-source-map-support/1.4.0:
@@ -8843,53 +8843,50 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: false
 
-  /mongodb-connection-string-url/2.1.0:
-    resolution: {integrity: sha512-Qf9Zw7KGiRljWvMrrUFDdVqo46KIEiDuCzvEN97rh/PcKzk2bd6n9KuzEwBwW9xo5glwx69y1mI6s+jFUD/aIQ==}
+  /mongodb-connection-string-url/2.5.2:
+    resolution: {integrity: sha512-tWDyIG8cQlI5k3skB6ywaEA5F9f5OntrKKsT/Lteub2zgwSUlhqEN2inGgBTm8bpYJf8QYBdA/5naz65XDpczA==}
     dependencies:
       '@types/whatwg-url': 8.2.1
-      whatwg-url: 9.1.0
+      whatwg-url: 11.0.0
     dev: true
 
-  /mongodb/4.1.2:
-    resolution: {integrity: sha512-pHCKDoOy1h6mVurziJmXmTMPatYWOx8pbnyFgSgshja9Y36Q+caHUzTDY6rrIy9HCSrjnbXmx3pCtvNZHmR8xg==}
+  /mongodb/4.7.0:
+    resolution: {integrity: sha512-HhVar6hsUeMAVlIbwQwWtV36iyjKd9qdhY+s4wcU8K6TOj4Q331iiMy+FoPuxEntDIijTYWivwFJkLv8q/ZgvA==}
     engines: {node: '>=12.9.0'}
     dependencies:
-      bson: 4.5.3
+      bson: 4.6.4
       denque: 2.0.1
-      mongodb-connection-string-url: 2.1.0
+      mongodb-connection-string-url: 2.5.2
+      socks: 2.6.2
     optionalDependencies:
       saslprep: 1.0.3
     dev: true
 
-  /mongoose/6.0.10:
-    resolution: {integrity: sha512-p/wiEDUXoQuyb/xQx8QW/YGN92ZsojJ5E/DDgMCUU0WOGxc5uhcWoZ7ijLu6Ssjq8UkwVSv+jzkYp4Wbr+NqBg==}
+  /mongoose/6.4.3:
+    resolution: {integrity: sha512-JuEdgpDxYIqG+V85LzNn7LKIr73ixnKVbmEhJNSf3vF1+QmIfar5S0wfL/s3CSM3qs/p6J2vWirOle1INW5VCA==}
     engines: {node: '>=12.0.0'}
     dependencies:
-      bson: 4.5.3
-      kareem: 2.3.2
-      mongodb: 4.1.2
-      mpath: 0.8.4
-      mquery: 4.0.0
-      ms: 2.1.2
-      regexp-clone: 1.0.0
-      sift: 13.5.2
-      sliced: 1.0.1
+      bson: 4.6.4
+      kareem: 2.4.1
+      mongodb: 4.7.0
+      mpath: 0.9.0
+      mquery: 4.0.3
+      ms: 2.1.3
+      sift: 16.0.0
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /mpath/0.8.4:
-    resolution: {integrity: sha512-DTxNZomBcTWlrMW76jy1wvV37X/cNNxPW1y2Jzd4DZkAaC5ZGsm8bfGfNOthcDuRJujXLqiuS6o3Tpy0JEoh7g==}
+  /mpath/0.9.0:
+    resolution: {integrity: sha512-ikJRQTk8hw5DEoFVxHG1Gn9T/xcjtdnOKIU1JTmGjZZlg9LST2mBLmcX3/ICIbgJydT2GOc15RnNy5mHmzfSew==}
     engines: {node: '>=4.0.0'}
     dev: true
 
-  /mquery/4.0.0:
-    resolution: {integrity: sha512-nGjm89lHja+T/b8cybAby6H0YgA4qYC/lx6UlwvHGqvTq8bDaNeCwl1sY8uRELrNbVWJzIihxVd+vphGGn1vBw==}
+  /mquery/4.0.3:
+    resolution: {integrity: sha512-J5heI+P08I6VJ2Ky3+33IpCdAvlYGTSUjwTPxkAr8i8EoduPMBX2OY/wa3IKZIQl7MU4SbFk8ndgSKyB/cl1zA==}
     engines: {node: '>=12.0.0'}
     dependencies:
-      debug: 4.3.1
-      regexp-clone: 1.0.0
-      sliced: 1.0.1
+      debug: 4.3.4
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -10256,10 +10253,6 @@ packages:
     resolution: {integrity: sha512-jbD/FT0+9MBU2XAZluI7w2OBs1RBi6p9M83nkoZayQXXU9e8Robt69FcZc7wU4eJD/YFTjn1JdCk3rbMJajz8Q==}
     dev: true
 
-  /regexp-clone/1.0.0:
-    resolution: {integrity: sha512-TuAasHQNamyyJ2hb97IuBEif4qBHGjPHBS64sZwytpLEqtBQ1gPJTnOaQ6qmpET16cK14kkjbazl6+p0RRv0yw==}
-    dev: true
-
   /regexp.prototype.flags/1.4.3:
     resolution: {integrity: sha512-fjggEOO3slI6Wvgjwflkc4NFRCTZAu5CnNfBd5qOMYhWdn67nJBBu34/TkD++eeFmd8C9r9jfXJ27+nSiRkSUA==}
     engines: {node: '>= 0.4'}
@@ -10731,8 +10724,8 @@ packages:
       get-intrinsic: 1.1.1
       object-inspect: 1.12.2
 
-  /sift/13.5.2:
-    resolution: {integrity: sha512-+gxdEOMA2J+AI+fVsCqeNn7Tgx3M9ZN9jdi95939l1IJ8cZsqS8sqpJyOkic2SJk+1+98Uwryt/gL6XDaV+UZA==}
+  /sift/16.0.0:
+    resolution: {integrity: sha512-ILTjdP2Mv9V1kIxWMXeMTIRbOBrqKc4JAXmFMnFq3fKeyQ2Qwa3Dw1ubcye3vR+Y6ofA0b9gNDr/y2t6eUeIzQ==}
     dev: true
 
   /signal-exit/3.0.3:
@@ -10777,8 +10770,9 @@ packages:
       is-fullwidth-code-point: 3.0.0
     dev: false
 
-  /sliced/1.0.1:
-    resolution: {integrity: sha1-CzpmK10Ewxd7GSa+qCsD+Dei70E=}
+  /smart-buffer/4.2.0:
+    resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
+    engines: {node: '>= 6.0.0', npm: '>= 3.0.0'}
     dev: true
 
   /sockjs/0.3.24:
@@ -10787,6 +10781,14 @@ packages:
       faye-websocket: 0.11.4
       uuid: 8.3.2
       websocket-driver: 0.7.4
+    dev: true
+
+  /socks/2.6.2:
+    resolution: {integrity: sha512-zDZhHhZRY9PxRruRMR7kMhnf3I8hDs4S3f9RecfnGxvcBHQcKcIH/oUcEWffsfl1XxdYlA7nnlGbbTvPz9D8gA==}
+    engines: {node: '>= 10.13.0', npm: '>= 3.0.0'}
+    dependencies:
+      ip: 1.1.8
+      smart-buffer: 4.2.0
     dev: true
 
   /source-map-js/1.0.2:
@@ -10849,7 +10851,7 @@ packages:
     dev: true
 
   /sparse-bitfield/3.0.3:
-    resolution: {integrity: sha1-/0rm5oZWBWuks+eSqzM004JzyhE=}
+    resolution: {integrity: sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==}
     dependencies:
       memory-pager: 1.5.0
     dev: true
@@ -11355,6 +11357,13 @@ packages:
     dependencies:
       punycode: 2.1.1
 
+  /tr46/3.0.0:
+    resolution: {integrity: sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==}
+    engines: {node: '>=12'}
+    dependencies:
+      punycode: 2.1.1
+    dev: true
+
   /traverse/0.6.6:
     resolution: {integrity: sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc=}
     dev: false
@@ -11708,6 +11717,11 @@ packages:
     resolution: {integrity: sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w==}
     engines: {node: '>=10.4'}
 
+  /webidl-conversions/7.0.0:
+    resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
+    engines: {node: '>=12'}
+    dev: true
+
   /webpack-dev-middleware/5.3.0_webpack@5.70.0:
     resolution: {integrity: sha512-MouJz+rXAm9B1OTOYaJnn6rtD/lWZPy2ufQCH3BPs8Rloh/Du6Jze4p7AeLYHkVi0giJnYLaSGDC7S+GM9arhg==}
     engines: {node: '>= 12.13.0'}
@@ -11874,6 +11888,14 @@ packages:
   /whatwg-mimetype/2.3.0:
     resolution: {integrity: sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==}
 
+  /whatwg-url/11.0.0:
+    resolution: {integrity: sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==}
+    engines: {node: '>=12'}
+    dependencies:
+      tr46: 3.0.0
+      webidl-conversions: 7.0.0
+    dev: true
+
   /whatwg-url/7.1.0:
     resolution: {integrity: sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==}
     dependencies:
@@ -11889,14 +11911,6 @@ packages:
       lodash: 4.17.21
       tr46: 2.1.0
       webidl-conversions: 6.1.0
-
-  /whatwg-url/9.1.0:
-    resolution: {integrity: sha512-CQ0UcrPHyomtlOCot1TL77WyMIm/bCwrJ2D6AOKGwEczU9EpyoqAokfqrf/MioU9kHcMsmJZcg1egXix2KYEsA==}
-    engines: {node: '>=12'}
-    dependencies:
-      tr46: 2.1.0
-      webidl-conversions: 6.1.0
-    dev: true
 
   /which-boxed-primitive/1.0.2:
     resolution: {integrity: sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,7 +105,7 @@ importers:
       '@types/jest': 26.0.22
       chai: 4.3.4
       chai-spies: 1.0.0_chai@4.3.4
-      mongoose: 6.4.3
+      mongoose: 6.0.13
 
   packages/casl-prisma:
     specifiers:
@@ -5589,8 +5589,8 @@ packages:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
 
-  /denque/2.0.1:
-    resolution: {integrity: sha512-tfiWc6BQLXNLpNiR5iGd0Ocu3P3VpxfzFiqubLgMfhfOw9WyvgJBd46CClNn9k3qfbjvT//0cf7AlYRX/OslMQ==}
+  /denque/2.1.0:
+    resolution: {integrity: sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==}
     engines: {node: '>=0.10'}
     dev: true
 
@@ -8319,8 +8319,8 @@ packages:
       object.assign: 4.1.2
     dev: false
 
-  /kareem/2.4.1:
-    resolution: {integrity: sha512-aJ9opVoXroQUPfovYP5kaj2lM7Jn02Gw13bL0lg9v0V7SaUc0qavPs0Eue7d2DcC3NjqI6QAUElXNsuZSeM+EA==}
+  /kareem/2.3.2:
+    resolution: {integrity: sha512-STHz9P7X2L4Kwn72fA4rGyqyXdmrMSdxqHx9IXon/FXluXieaFA6KJ2upcHAHxQPQ0LeM/OjLrhFxifHewOALQ==}
     dev: true
 
   /karma-source-map-support/1.4.0:
@@ -8850,43 +8850,46 @@ packages:
       whatwg-url: 11.0.0
     dev: true
 
-  /mongodb/4.7.0:
-    resolution: {integrity: sha512-HhVar6hsUeMAVlIbwQwWtV36iyjKd9qdhY+s4wcU8K6TOj4Q331iiMy+FoPuxEntDIijTYWivwFJkLv8q/ZgvA==}
+  /mongodb/4.1.4:
+    resolution: {integrity: sha512-Cv/sk8on/tpvvqbEvR1h03mdyNdyvvO+WhtFlL4jrZ+DSsN/oSQHVqmJQI/sBCqqbOArFcYCAYDfyzqFwV4GSQ==}
     engines: {node: '>=12.9.0'}
     dependencies:
       bson: 4.6.4
-      denque: 2.0.1
+      denque: 2.1.0
       mongodb-connection-string-url: 2.5.2
-      socks: 2.6.2
     optionalDependencies:
       saslprep: 1.0.3
     dev: true
 
-  /mongoose/6.4.3:
-    resolution: {integrity: sha512-JuEdgpDxYIqG+V85LzNn7LKIr73ixnKVbmEhJNSf3vF1+QmIfar5S0wfL/s3CSM3qs/p6J2vWirOle1INW5VCA==}
+  /mongoose/6.0.13:
+    resolution: {integrity: sha512-/M/YKgx23fCX+j0lwObaHbCibXnMjyWeQrXZf0WaQeS/hL86wQVSmaOxh+kZXfyLOUr+vT2Hl44o50GZHUrKWw==}
     engines: {node: '>=12.0.0'}
     dependencies:
       bson: 4.6.4
-      kareem: 2.4.1
-      mongodb: 4.7.0
-      mpath: 0.9.0
-      mquery: 4.0.3
-      ms: 2.1.3
-      sift: 16.0.0
+      kareem: 2.3.2
+      mongodb: 4.1.4
+      mpath: 0.8.4
+      mquery: 4.0.0
+      ms: 2.1.2
+      regexp-clone: 1.0.0
+      sift: 13.5.2
+      sliced: 1.0.1
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /mpath/0.9.0:
-    resolution: {integrity: sha512-ikJRQTk8hw5DEoFVxHG1Gn9T/xcjtdnOKIU1JTmGjZZlg9LST2mBLmcX3/ICIbgJydT2GOc15RnNy5mHmzfSew==}
+  /mpath/0.8.4:
+    resolution: {integrity: sha512-DTxNZomBcTWlrMW76jy1wvV37X/cNNxPW1y2Jzd4DZkAaC5ZGsm8bfGfNOthcDuRJujXLqiuS6o3Tpy0JEoh7g==}
     engines: {node: '>=4.0.0'}
     dev: true
 
-  /mquery/4.0.3:
-    resolution: {integrity: sha512-J5heI+P08I6VJ2Ky3+33IpCdAvlYGTSUjwTPxkAr8i8EoduPMBX2OY/wa3IKZIQl7MU4SbFk8ndgSKyB/cl1zA==}
+  /mquery/4.0.0:
+    resolution: {integrity: sha512-nGjm89lHja+T/b8cybAby6H0YgA4qYC/lx6UlwvHGqvTq8bDaNeCwl1sY8uRELrNbVWJzIihxVd+vphGGn1vBw==}
     engines: {node: '>=12.0.0'}
     dependencies:
       debug: 4.3.4
+      regexp-clone: 1.0.0
+      sliced: 1.0.1
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -10253,6 +10256,10 @@ packages:
     resolution: {integrity: sha512-jbD/FT0+9MBU2XAZluI7w2OBs1RBi6p9M83nkoZayQXXU9e8Robt69FcZc7wU4eJD/YFTjn1JdCk3rbMJajz8Q==}
     dev: true
 
+  /regexp-clone/1.0.0:
+    resolution: {integrity: sha512-TuAasHQNamyyJ2hb97IuBEif4qBHGjPHBS64sZwytpLEqtBQ1gPJTnOaQ6qmpET16cK14kkjbazl6+p0RRv0yw==}
+    dev: true
+
   /regexp.prototype.flags/1.4.3:
     resolution: {integrity: sha512-fjggEOO3slI6Wvgjwflkc4NFRCTZAu5CnNfBd5qOMYhWdn67nJBBu34/TkD++eeFmd8C9r9jfXJ27+nSiRkSUA==}
     engines: {node: '>= 0.4'}
@@ -10724,8 +10731,8 @@ packages:
       get-intrinsic: 1.1.1
       object-inspect: 1.12.2
 
-  /sift/16.0.0:
-    resolution: {integrity: sha512-ILTjdP2Mv9V1kIxWMXeMTIRbOBrqKc4JAXmFMnFq3fKeyQ2Qwa3Dw1ubcye3vR+Y6ofA0b9gNDr/y2t6eUeIzQ==}
+  /sift/13.5.2:
+    resolution: {integrity: sha512-+gxdEOMA2J+AI+fVsCqeNn7Tgx3M9ZN9jdi95939l1IJ8cZsqS8sqpJyOkic2SJk+1+98Uwryt/gL6XDaV+UZA==}
     dev: true
 
   /signal-exit/3.0.3:
@@ -10770,9 +10777,8 @@ packages:
       is-fullwidth-code-point: 3.0.0
     dev: false
 
-  /smart-buffer/4.2.0:
-    resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
-    engines: {node: '>= 6.0.0', npm: '>= 3.0.0'}
+  /sliced/1.0.1:
+    resolution: {integrity: sha512-VZBmZP8WU3sMOZm1bdgTadsQbcscK0UM8oKxKVBs4XAhUo2Xxzm/OFMGBkPusxw9xL3Uy8LrzEqGqJhclsr0yA==}
     dev: true
 
   /sockjs/0.3.24:
@@ -10781,14 +10787,6 @@ packages:
       faye-websocket: 0.11.4
       uuid: 8.3.2
       websocket-driver: 0.7.4
-    dev: true
-
-  /socks/2.6.2:
-    resolution: {integrity: sha512-zDZhHhZRY9PxRruRMR7kMhnf3I8hDs4S3f9RecfnGxvcBHQcKcIH/oUcEWffsfl1XxdYlA7nnlGbbTvPz9D8gA==}
-    engines: {node: '>= 10.13.0', npm: '>= 3.0.0'}
-    dependencies:
-      ip: 1.1.8
-      smart-buffer: 4.2.0
     dev: true
 
   /source-map-js/1.0.2:


### PR DESCRIPTION
* Allow to use without `extends Document` syntax
* Requires at least Mongoose 6.0.13 due to `HydratedDocument`
* See https://github.com/stalniy/casl/issues/634

Closes #634 