### PR TITLE
fix: When use rollup or RN to build, it is necessary to explicitly add `"./package.json": "./package.json"` to their `exports` field

### DIFF
--- a/packages/casl-ability/package.json
+++ b/packages/casl-ability/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@casl/ability",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "description": "CASL is an isomorphic authorization JavaScript library which restricts what resources a given user is allowed to access",
   "funding": "https://github.com/stalniy/casl/blob/master/BACKERS.md",
   "main": "dist/es6c/index.js",
@@ -16,7 +16,8 @@
     "./extra": {
       "import": "./dist/es6m/extra.mjs",
       "require": "./dist/es6c/extra.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "sideEffects": false,
   "repository": {

--- a/packages/casl-ability/package.json
+++ b/packages/casl-ability/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@casl/ability",
-  "version": "6.0.1",
+  "version": "6.0.0",
   "description": "CASL is an isomorphic authorization JavaScript library which restricts what resources a given user is allowed to access",
   "funding": "https://github.com/stalniy/casl/blob/master/BACKERS.md",
   "main": "dist/es6c/index.js",


### PR DESCRIPTION
When use rollup or RN to build, it is necessary to explicitly add `"./package.json": "./package.json"` to their `exports` field.