### PR TITLE
fix: broken types in typescript 4.8

### DIFF
--- a/packages/casl-ability/src/matchers/conditions.ts
+++ b/packages/casl-ability/src/matchers/conditions.ts
@@ -72,9 +72,9 @@ interface MongoQueryFactory extends GenericFactory {
 }
 
 type MergeUnion<T extends {}, Keys extends keyof T = keyof T> = { [K in Keys]: T[K] };
-export type MongoQuery<T = AnyObject> = BuildMongoQuery<MergeUnion<T>, {
+export type MongoQuery<T = AnyObject> = BuildMongoQuery<MergeUnion<NonNullable<T>>, {
   toplevel: {},
-  field: Pick<DefaultOperators<MergeUnion<T>>['field'], keyof typeof defaultInstructions>
+  field: Pick<DefaultOperators<MergeUnion<NonNullable<T>>>['field'], keyof typeof defaultInstructions>
 }> & Container<MongoQueryFactory>;
 
 type MongoQueryMatcherFactory =


### PR DESCRIPTION
Cast explicitly to `NonNullable<T>`

Source: https://devblogs.microsoft.com/typescript/announcing-typescript-4-8-rc/#improved-intersection-reduction-union-compatibility-and-narrowing

Fixes https://github.com/stalniy/casl/issues/673