### PR TITLE
Fixed broken link in docs: missing https:// in external link

### DIFF
--- a/docs-src/src/content/pages/api/casl-ability-extra/en.md
+++ b/docs-src/src/content/pages/api/casl-ability-extra/en.md
@@ -21,7 +21,7 @@ This is a helper iterator function that allows to aggregate conditions from perm
 
 ## rulesToAST
 
-This function converts rules into [ucast](github.com/stalniy/ucast) AST.
+This function converts rules into [ucast](https://github.com/stalniy/ucast) AST.
 
 * **Parameters**:
   * `ability: TAbility`


### PR DESCRIPTION
Hi, I found a broken link in the @casl/ability/extra API