### PR TITLE
(casl-mongoose) fix: Proper typing for Mongoose plugins

### DIFF
--- a/packages/casl-mongoose/src/accessible_fields.ts
+++ b/packages/casl-mongoose/src/accessible_fields.ts
@@ -10,7 +10,7 @@ export type AccessibleFieldsOptions =
 
 export const getSchemaPaths: AccessibleFieldsOptions['getFields'] = schema => Object.keys((schema as { paths: object }).paths);
 
-function fieldsOf(schema: Schema<Document>, options: Partial<AccessibleFieldsOptions>) {
+function fieldsOf(schema: Schema<Document, any>, options: Partial<AccessibleFieldsOptions>) {
   const fields = options.getFields!(schema);
 
   if (!options || !('except' in options)) {
@@ -48,7 +48,10 @@ export interface AccessibleFieldsDocument extends Document, AccessibleFieldDocum
 
 function modelFieldsGetter() {
   let fieldsFrom: PermittedFieldsOptions<AnyMongoAbility>['fieldsFrom'];
-  return (schema: Schema<any>, options: Partial<AccessibleFieldsOptions>) => {
+  return (
+    schema: Schema<any, AccessibleFieldsModel<any>>,
+    options: Partial<AccessibleFieldsOptions>
+  ) => {
     if (!fieldsFrom) {
       const ALL_FIELDS = options && 'only' in options
         ? wrapArray(options.only as string[])
@@ -60,8 +63,8 @@ function modelFieldsGetter() {
   };
 }
 
-export function accessibleFieldsPlugin(
-  schema: Schema<any>,
+export function accessibleFieldsPlugin<T>(
+  schema: Schema<T, AccessibleFieldsModel<T>>,
   rawOptions?: Partial<AccessibleFieldsOptions>
 ): void {
   const options = { getFields: getSchemaPaths, ...rawOptions };
@@ -73,7 +76,7 @@ export function accessibleFieldsPlugin(
     });
   }
 
-  function modelAccessibleFields(this: Model<unknown>, ability: AnyMongoAbility, action?: string) {
+  function modelAccessibleFields(this: Model<T>, ability: AnyMongoAbility, action?: string) {
     const document = { constructor: this };
     return permittedFieldsOf(ability, action || 'read', document, {
       fieldsFrom: fieldsFrom(schema, options)

--- a/packages/casl-mongoose/src/accessible_records.ts
+++ b/packages/casl-mongoose/src/accessible_records.ts
@@ -77,7 +77,7 @@ export interface AccessibleRecordModel<
   >
 }
 
-function modelAccessibleBy(this: Model<unknown>, ability: AnyMongoAbility, action?: string) {
+function modelAccessibleBy<T>(this: Model<T>, ability: AnyMongoAbility, action?: string) {
   return accessibleBy(this.where(), ability, action);
 }
 
@@ -89,7 +89,7 @@ function queryAccessibleBy(
   return accessibleBy(this, ability, action);
 }
 
-export function accessibleRecordsPlugin(schema: Schema<any>): void {
+export function accessibleRecordsPlugin<T>(schema: Schema<T, AccessibleRecordModel<T>>): void {
   (schema.query as Record<string, unknown>).accessibleBy = queryAccessibleBy;
   schema.statics.accessibleBy = modelAccessibleBy;
 }


### PR DESCRIPTION
Hi @stalniy -

I continue to enjoy using CASL - thank you for your work! After updating Mongoose in one of our projects I got compile errors here:

```typescript
mySchema.plugin(accessibleRecordsPlugin);
mySchema.plugin(accessibleFieldsPlugin);
```

Mongoose 6.6.3 made the plugin typing more strict, which currently leads to a TS error which I have to `@ts-ignore`

See here about the change: 

https://github.com/Automattic/mongoose/commit/2b0d4292b13dba6538a3759aa75f06dfbf7f7740

These changes add the second type parameter to `Schema` which resolves the issue. The fix should be non-breaking.