### PR TITLE
(casl-mongoose) feat: Export AccessibleFieldDocumentMethods interface

### DIFF
--- a/packages/casl-mongoose/src/index.ts
+++ b/packages/casl-mongoose/src/index.ts
@@ -23,6 +23,7 @@ export { getSchemaPaths, accessibleFieldsPlugin } from './accessible_fields';
 export type {
   AccessibleFieldsModel,
   AccessibleFieldsDocument,
-  AccessibleFieldsOptions
+  AccessibleFieldsOptions,
+  AccessibleFieldDocumentMethods
 } from './accessible_fields';
 export { toMongoQuery } from './mongo';


### PR DESCRIPTION
It would be good to have the `AccessibleFieldDocumentMethods` interface exported. This makes it easier to further add further document methods: 

```typescript
import { accessibleFieldsPlugin, accessibleRecordsPlugin, AccessibleFieldDocumentMethods, AccessibleModel } from '@casl/mongoose';

interface IUserMethods extends AccessibleFieldDocumentMethods {
  validPassword(password: string): Promise<boolean>;
}

type UserModel = AccessibleModel<IUser, Record<string, never>, IUserMethods, IUserVirtuals>;
export type UserDocument = mongoose.HydratedDocument<IUser, IUserMethods, IUserVirtuals>;
```