### PR TITLE
docs(react-README): updates links to point to /v6

### DIFF
--- a/packages/casl-react/README.md
+++ b/packages/casl-react/README.md
@@ -114,7 +114,7 @@ export default function App({ props }) {
 }
 ```
 
-> See [CASL guide](https://casl.js.org/v5/en/guide/intro) to learn how to define `Ability` instance.
+> See [CASL guide](https://casl.js.org/v6/en/guide/intro) to learn how to define `Ability` instance.
 
 and use our `Can` component:
 
@@ -302,7 +302,7 @@ export default () => {
 };
 ```
 
-> See [Define rules](https://casl.js.org/v5/en/guide/define-rules) to get more information of how to define `Ability`
+> See [Define rules](https://casl.js.org/v6/en/guide/define-rules) to get more information of how to define `Ability`
 
 ## Want to help?
 
@@ -310,7 +310,7 @@ Want to file a bug, contribute some code, or improve documentation? Excellent! R
 
 If you'd like to help us sustain our community and project, consider [to become a financial contributor on Open Collective](https://opencollective.com/casljs/contribute)
 
-> See [Support CASL](https://casl.js.org/v5/en/support-casljs) for details
+> See [Support CASL](https://casl.js.org/v6/en/support-casljs) for details
 
 ## License
 


### PR DESCRIPTION
Hey team 👋 Thanks a lot for the work put on this package 👍 

- [x] I checked that all links to `v6` are working.