### PR TITLE
feat: added additionalData field to Rule class

### DIFF
--- a/packages/casl-ability/src/RawRule.ts
+++ b/packages/casl-ability/src/RawRule.ts
@@ -7,6 +7,11 @@ interface BaseRawRule<Conditions> {
   inverted?: boolean
   /** explains the reason of why rule does not allow to do something */
   reason?: string
+  /** Any custom information.
+   * Usually can be used to trace rule source.
+   * Also can be used to store additional options related with action.
+   */
+  additionalData?: any
 }
 
 export interface ClaimRawRule<A extends string> extends BaseRawRule<undefined> {

--- a/packages/casl-ability/src/Rule.ts
+++ b/packages/casl-ability/src/Rule.ts
@@ -42,6 +42,7 @@ export class Rule<A extends Abilities, C> {
   public readonly conditions!: C | undefined;
   public readonly fields!: string[] | undefined;
   public readonly reason!: string | undefined;
+  public readonly additionalData!: any;
   public readonly priority!: number;
 
   constructor(
@@ -56,6 +57,7 @@ export class Rule<A extends Abilities, C> {
     this.inverted = !!rule.inverted;
     this.conditions = rule.conditions;
     this.reason = rule.reason;
+    this.additionalData = rule.additionalData;
     this.fields = rule.fields ? wrapArray(rule.fields) : undefined;
     this.priority = priority;
     this._options = options;


### PR DESCRIPTION
Allow store additional debug info at rules. 
I want store here source of this rule (groupId, teamId, description).
Also i want store here some specific options related to 'create' action to put them to created resource.

It will very helpful to use with `relevantRuleFor`.