### PR TITLE
Update package.json to support prisma 5

### DIFF
--- a/packages/casl-prisma/package.json
+++ b/packages/casl-prisma/package.json
@@ -48,7 +48,7 @@
   "license": "MIT",
   "peerDependencies": {
     "@casl/ability": "^5.3.0 || ^6.0.0",
-    "@prisma/client": "^2.14.0 || ^3.0.0 || ^4.0.0"
+    "@prisma/client": "^2.14.0 || ^3.0.0 || ^4.0.0 || ^5.0.0"
   },
   "devDependencies": {
     "@casl/ability": "^6.0.0",


### PR DESCRIPTION
Only pumped for support to prisma `^5.0.0` 

This is the output of the tests, all passed:
```
huthaifamuayyad@localhost casl % pnpm run -r test
Scope: 8 of 9 workspace projects
packages/casl-ability test$ dx jest
[6 lines collapsed]
│  PASS  spec/subject_helper.spec.ts
│  PASS  spec/error.spec.ts
│  PASS  spec/types/AbilityBuilder.spec.ts
│  PASS  spec/types/Ability.spec.ts
│  PASS  spec/pack_rules.spec.ts
│ Test Suites: 11 passed, 11 total
│ Tests:       178 passed, 178 total
│ Snapshots:   0 total
│ Time:        2.192 s
│ Ran all test suites.
└─ Done in 2.7s
packages/casl-aurelia test$ dx jest --env jsdom --config ../dx/config/jest.chai.config.js
[8 lines collapsed]
│       ✓ allows to check abilities using `can` value converter (6 ms)
│       ✓ re-calls `can` value converter when that instance is updated (6 ms)
│     when `PureAbility` instance is not passed as a plugin parameter but was registered in DI container
│       ✓ allows to check abilities using `can` value converter (3 ms)
│       ✓ re-calls `can` value converter when that instance is updated (5 ms)
│ Test Suites: 1 passed, 1 total
│ Tests:       8 passed, 8 total
│ Snapshots:   0 total
│ Time:        1.197 s
│ Ran all test suites.
└─ Done in 1.5s
packages/casl-angular test$ dx jest --config ./jest.config.js
│  PASS  spec/AblePipe.spec.ts
│  PASS  spec/AbilityService.spec.ts
│  PASS  spec/AbilityModule.e2e.spec.ts
│ Test Suites: 3 passed, 3 total
│ Tests:       10 passed, 10 total
│ Snapshots:   0 total
│ Time:        2.411 s
│ Ran all test suites.
└─ Done in 2.8s
packages/casl-mongoose test$ dx jest
│  PASS  spec/mongo_query.spec.ts
│  PASS  spec/accessible_records.spec.ts
│  PASS  spec/accessible_fields.spec.ts
│ Test Suites: 3 passed, 3 total
│ Tests:       39 passed, 39 total
│ Snapshots:   0 total
│ Time:        3.444 s
│ Ran all test suites.
└─ Done in 3.8s
packages/casl-prisma test$ dx jest
│  PASS  spec/accessibleBy.spec.ts
│  PASS  spec/prismaQuery.spec.ts
│  PASS  spec/PrismaAbility.spec.ts
│ Test Suites: 3 passed, 3 total
│ Tests:       60 passed, 60 total
│ Snapshots:   0 total
│ Time:        1.375 s
│ Ran all test suites.
└─ Done in 1.7s
packages/casl-react test$ dx jest --env jsdom --config ../dx/config/jest.chai.config.js
│  PASS  spec/Can.spec.js
│  PASS  spec/factory.spec.js
│  PASS  spec/useAbility.spec.js
│ Test Suites: 3 passed, 3 total
│ Tests:       22 passed, 22 total
│ Snapshots:   0 total
│ Time:        1.765 s
│ Ran all test suites.
└─ Done in 2.2s
packages/casl-vue test$ dx jest --env jsdom --config ../dx/config/jest.chai.config.js
│  PASS  spec/can.spec.js
│  PASS  spec/plugin.spec.js
│  PASS  spec/hooks.spec.js
│ Test Suites: 3 passed, 3 total
│ Tests:       21 passed, 21 total
│ Snapshots:   0 total
│ Time:        1.73 s
│ Ran all test suites.
└─ Done in 2.1s
huthaifamuayyad@localhost casl %
```