### PR TITLE
feat: adds accessibleBy helper and deprecates `toMongoQuery` and `accessibleRecordsPlugin`

### DIFF
--- a/packages/casl-mongoose/spec/accessibleBy.spec.ts
+++ b/packages/casl-mongoose/spec/accessibleBy.spec.ts
@@ -1,0 +1,37 @@
+import { defineAbility } from "@casl/ability"
+import { accessibleBy } from "../src"
+import { testConversionToMongoQuery } from "./mongo_query.spec"
+
+declare module '../src' {
+  interface RecordTypes {
+    Post: true
+  }
+}
+
+describe('accessibleBy', () => {
+  it('returns `{ $expr: false }` when there are no rules for specific subject/action', () => {
+    const ability = defineAbility((can) => {
+      can('read', 'Post')
+    })
+
+    const query = accessibleBy(ability, 'update').Post
+
+    expect(query).toEqual({ $expr: false })
+  })
+
+  it('returns `{ $expr: false }` if there is a rule that forbids previous one', () => {
+    const ability = defineAbility((can, cannot) => {
+      can('update', 'Post', { authorId: 1 })
+      cannot('update', 'Post')
+    })
+
+    const query = accessibleBy(ability, 'update').Post
+
+    expect(query).toEqual({ $expr: false })
+  })
+
+  describe('it behaves like `toMongoQuery` when converting rules', () => {
+    testConversionToMongoQuery((ability, subjectType, action) =>
+      accessibleBy(ability, action)[subjectType])
+  })
+})

--- a/packages/casl-mongoose/src/accessible_records.ts
+++ b/packages/casl-mongoose/src/accessible_records.ts
@@ -8,7 +8,7 @@ function failedQuery(
   modelName: string,
   query: QueryWithHelpers<Document, Document>
 ) {
-  query.where({ __forbiddenByCasl__: 1 }); // eslint-disable-line
+  query.where({ $expr: false }); // rule that returns empty result set
   const anyQuery: any = query;
 
   if (typeof anyQuery.pre === 'function') {
@@ -53,6 +53,7 @@ AccessibleRecordQueryHelpers<T, TQueryHelpers, TMethods, TVirtuals>
 >;
 
 export type AccessibleRecordQueryHelpers<T, TQueryHelpers = {}, TMethods = {}, TVirtuals = {}> = {
+  /** @deprecated use accessibleBy helper instead */
   accessibleBy: GetAccessibleRecords<
   HydratedDocument<T, TMethods, TVirtuals>,
   TQueryHelpers,
@@ -69,6 +70,7 @@ export interface AccessibleRecordModel<
   TQueryHelpers & AccessibleRecordQueryHelpers<T, TQueryHelpers, TMethods, TVirtuals>,
   TMethods,
   TVirtuals> {
+  /** @deprecated use accessibleBy helper instead */
   accessibleBy: GetAccessibleRecords<
   HydratedDocument<T, TMethods, TVirtuals>,
   TQueryHelpers,

--- a/packages/casl-mongoose/src/index.ts
+++ b/packages/casl-mongoose/src/index.ts
@@ -25,4 +25,6 @@ export type {
   AccessibleFieldsDocument,
   AccessibleFieldsOptions
 } from './accessible_fields';
-export { toMongoQuery } from './mongo';
+
+export { toMongoQuery, accessibleBy } from './mongo';
+export type { RecordTypes } from './mongo';

--- a/packages/casl-mongoose/src/mongo.ts
+++ b/packages/casl-mongoose/src/mongo.ts
@@ -7,6 +7,8 @@ function convertToMongoQuery(rule: AnyMongoAbility['rules'][number]) {
 }
 
 /**
+ * @deprecated use accessibleBy instead
+ *
  * Converts ability action + subjectType to MongoDB query
  */
 export function toMongoQuery<T extends AnyMongoAbility>(
@@ -16,3 +18,28 @@ export function toMongoQuery<T extends AnyMongoAbility>(
 ): AbilityQuery | null {
   return rulesToQuery(ability, action, subjectType, convertToMongoQuery);
 }
+
+export interface RecordTypes {
+}
+type StringOrKeysOf<T> = keyof T extends never ? string : keyof T;
+
+/**
+ * Returns Mongo query per record type (i.e., entity type) based on provided Ability and action.
+ * In case action is not allowed, it returns `{ $expr: false }`
+ */
+export function accessibleBy<T extends AnyMongoAbility>(
+  ability: T,
+  action: Parameters<T['rulesFor']>[0] = 'read'
+): Record<StringOrKeysOf<RecordTypes>, AbilityQuery> {
+  return new Proxy({
+    _ability: ability,
+    _action: action
+  }, accessibleByProxyHandlers) as unknown as Record<StringOrKeysOf<RecordTypes>, AbilityQuery>;
+}
+
+const accessibleByProxyHandlers: ProxyHandler<{ _ability: AnyMongoAbility, _action: string }> = {
+  get(target, subjectType) {
+    const query = rulesToQuery(target._ability, target._action, subjectType, convertToMongoQuery);
+    return query === null ? { $expr: false } : query;
+  }
+};


### PR DESCRIPTION
**Before**

```ts
PostSchema = new Schema({})
PostSchema.plugin(accessibleRecordsPlugin)
const Post = mongoose.model<...>('Post', Post)

Post.accessibleBy(ability, 'read')
```

**After**

```ts
PostSchema = new Schema({})
const Post = mongoose.model<...>('Post', Post)
Post.find(accessibleBy(ability, 'read').Post)
```