### PR TITLE
Strongly type 'rulesToQuery' return based on return from 'convert' param

### DIFF
--- a/packages/casl-ability/src/extra.ts
+++ b/packages/casl-ability/src/extra.ts
@@ -6,19 +6,19 @@ import { Rule } from './Rule';
 import { setByPath, wrapArray } from './utils';
 import { AnyObject, SubjectType, ExtractSubjectType } from './types';
 
-export type RuleToQueryConverter<T extends AnyAbility> = (rule: RuleOf<T>) => object;
+export type RuleToQueryConverter<T extends AnyAbility, R = object> = (rule: RuleOf<T>) => R;
 export interface AbilityQuery<T = object> {
   $or?: T[]
   $and?: T[]
 }
 
-export function rulesToQuery<T extends AnyAbility>(
+export function rulesToQuery<T extends AnyAbility, R = object>(
   ability: T,
   action: Parameters<T['rulesFor']>[0],
   subjectType: ExtractSubjectType<Parameters<T['rulesFor']>[1]>,
-  convert: RuleToQueryConverter<T>
-): AbilityQuery | null {
-  const query: AbilityQuery = {};
+  convert: RuleToQueryConverter<T, R>
+): AbilityQuery<R> | null {
+  const query: AbilityQuery<R> = {};
   const rules = ability.rulesFor(action, subjectType);
 
   for (let i = 0; i < rules.length; i++) {


### PR DESCRIPTION
Fixes https://github.com/stalniy/casl/issues/875

Backwards compatibility should be maintained because:
1. Any consumer explicitly importing and specifying `T` in `RuleToQueryConverter<T>` can continue to do so because the new generic param has a default
2. Likewise for consumers choosing to explicitly specify `T` in `rulesToQuery<T>`