### PR TITLE
Export AddRule type from AbilityBuilder

### DIFF
--- a/packages/casl-ability/src/AbilityBuilder.ts
+++ b/packages/casl-ability/src/AbilityBuilder.ts
@@ -72,7 +72,7 @@ type BuilderCanParametersWithFields<
   : SimpleCanParams<T>;
 type Keys<T> = string & keyof T;
 
-type AddRule<T extends AnyAbility> = {
+export type AddRule<T extends AnyAbility> = {
   <
     I extends InstanceOf<T, S>,
     F extends string = Keys<I>,


### PR DESCRIPTION
When using `"moduleResolution": "Bundler"` in tsconfig.json for a TypeScript project, and implicitly referencing `AddRule` you get this error:

```bash
The inferred type of '<my-own-function>' cannot be named without a reference to '../../../node_modules/@casl/ability/dist/types/types'. This is likely not portable. A type annotation is necessary.ts(2742)
```

These errors can be resolved by explicitly exporting these implicitly referenced types from `@casl/ability`, like in this PR. 

My use case is something like this:

```ts
type Can = AbilityBuilder<UserAbility>['can'];
type Cannot = AbilityBuilder<UserAbility>['cannot'];
```

Where I then use these two types so that I can pass around `can`'s and `cannot`'s from my built ability into different functions. 

Thanks!