### PR TITLE
refactor: removes contextApiPatch.d.ts file from @casl/react to get rid of possible confusion in tools that can greedily include this file into compilation targets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,7 +70,7 @@ jobs:
             else
               if [ "$released_packages" != "" ]; then
                 echo -e "# Release notes for packages that will be published after merge\n\n" > release_notes.txt
-                echo "$release_notes" | sed 's/\x1B\[[0-9;]\{1,\}[A-Za-z]//g' | sed '/^##/,$!d' >> release_notes.txt
+                echo "$release_notes" | sed 's/\x1B\[[0-9;]\{1,\}[A-Za-z]//g' | sed -ne '/[0-9]*:[0-9]*:[0-9]* *[AP]M\] *\[semantic-release\] *› *ℹ *Release note for version/,$ p' >> release_notes.txt
                 gh pr comment "${{ github.event.pull_request.number }}" --body-file ./release_notes.txt
                 rm -f release_notes.txt
               else

--- a/packages/casl-react/README.md
+++ b/packages/casl-react/README.md
@@ -205,14 +205,22 @@ export default () => {
 
 ### Usage note on React < 16.4 with TypeScript
 
-If you use TypeScript and React < 16.4 make sure to add `@casl/react/contextAPIPatch.d.ts` file in your `tscofig.json`, otherwise your app won't compile:
+If you use TypeScript and React < 16.4 make sure to create a file `contextAPIPatch.d.ts` file with the next content:
+
+```ts
+declare module 'react' {
+  export type Consumer<T> = any;
+}
+```
+
+and include it in your `tscofig.json`, otherwise your app won't compile:
 
 ```json
 {
   // other configuration options
   "include": [
     "src/**/*",
-    "@casl/react/contextAPIPatch.d.ts" // <-- add this line
+    "./contextAPIPatch.d.ts" // <-- add this line
   ]
 }
 ```

--- a/packages/casl-react/contextApiPatch.d.ts
+++ b/packages/casl-react/contextApiPatch.d.ts
@@ -1,3 +1,0 @@
-declare module 'react' {
-  export type Consumer<T> = any;
-}


### PR DESCRIPTION

BREAKING CHANGE: removes contextApiPatch.d.ts file from @casl/react to get rid of possible confusion. The only affected apps are those which are based on React < 16.4.

Fixes #920