### PR TITLE
feat: update accessibleBy function of casl/prisma to autocomplete action names

### DIFF
--- a/packages/casl-prisma/spec/AppAbility.ts
+++ b/packages/casl-prisma/spec/AppAbility.ts
@@ -2,7 +2,7 @@ import { PureAbility } from '@casl/ability'
 import { User, Post } from '@prisma/client'
 import { PrismaQuery, Subjects } from '../src'
 
-export type AppAbility = PureAbility<[string, 'all' | Subjects<{
+export type AppAbility = PureAbility<['create' | "read" | "update" | "delete", 'all' | Subjects<{
   User: User,
   Post: Post
 }>], PrismaQuery>

--- a/packages/casl-prisma/src/accessibleByFactory.ts
+++ b/packages/casl-prisma/src/accessibleByFactory.ts
@@ -35,10 +35,10 @@ export const createAccessibleByFactory = <
   TResult extends Record<string, unknown>,
   TPrismaQuery
 >() => {
-  return function accessibleBy(ability: PureAbility<any, TPrismaQuery>, action = 'read'): TResult {
+  return function accessibleBy<TAbility extends PureAbility<any, TPrismaQuery>>(ability: TAbility, action: TAbility["rules"][number]["action"] = "read"): TResult {
     return new Proxy({
-      _ability: ability,
-      _action: action
+        _ability: ability,
+        _action: action,
     }, proxyHandlers) as unknown as TResult;
   };
 };


### PR DESCRIPTION
When using the `accessibleBy` function of `casl/prisma`, the action names property is not autocompleted in Typescript although it could be inferred.

e.g. in this case `update` would not be autocompleted which could result in issues and causes a degraded DX.
```
accessibleBy(ability, 'update')
```

This PR infers the possible actions from the ability passed as the first parameter.