### PR TITLE
feat(@casl/react): Pass forbidden reason message to child render function

### DIFF
--- a/packages/casl-ability/spec/error.spec.ts
+++ b/packages/casl-ability/spec/error.spec.ts
@@ -24,7 +24,7 @@ describe('`ForbiddenError` class', () => {
 
     it('does not produce error on forbidden action when inverted', () => {
       const { error } = setup()
-      expect(error.unlessCannot('read', 'Post')).toBeUndefined()
+      expect(error.unlessCannot('archive', 'Post')).toBeUndefined()
     })
 
     it('produces an error on allowed action when inverted', () => {

--- a/packages/casl-ability/spec/error.spec.ts
+++ b/packages/casl-ability/spec/error.spec.ts
@@ -1,120 +1,99 @@
-import {
-  ForbiddenError,
-  getDefaultErrorMessage,
-  PureAbility,
-  SubjectType,
-} from "../src"
+import { ForbiddenError, getDefaultErrorMessage, PureAbility, SubjectType } from '../src'
 
-describe("`ForbiddenError` class", () => {
-  describe("`throwUnlessCan` method", () => {
-    it("raises forbidden exception on disallowed action", () => {
+describe('`ForbiddenError` class', () => {
+  describe('`throwUnlessCan` method', () => {
+    it('raises forbidden exception on disallowed action', () => {
       const { error } = setup()
-      expect(() => error.throwUnlessCan("archive", "Post")).toThrow(
-        ForbiddenError as unknown as Error
-      )
+      expect(() => error.throwUnlessCan('archive', 'Post')).toThrow(ForbiddenError as unknown as Error)
     })
 
-    it("does not raise forbidden exception on disallowed action when inverted", () => {
+    it('does not raise forbidden exception on disallowed action when inverted', () => {
       const { error } = setup()
-      expect(() => error.throwUnlessCannot("archive", "Post")).not.toThrow(
-        ForbiddenError as unknown as Error
-      )
+      expect(() => error.throwUnlessCannot('archive', 'Post')).not.toThrow(ForbiddenError as unknown as Error)
     })
 
-    it("does not raise forbidden exception on allowed action", () => {
+    it('does not raise forbidden exception on allowed action', () => {
       const { error } = setup()
-      expect(() => error.throwUnlessCan("read", "Post")).not.toThrow(
-        ForbiddenError as unknown as Error
-      )
+      expect(() => error.throwUnlessCan('read', 'Post')).not.toThrow(ForbiddenError as unknown as Error)
     })
 
-    it("raises forbidden exception on allowed action when inverted", () => {
+    it('raises forbidden exception on allowed action when inverted', () => {
       const { error } = setup()
-      expect(() => error.throwUnlessCannot("read", "Post")).toThrow(
-        ForbiddenError as unknown as Error
-      )
+      expect(() => error.throwUnlessCannot('read', 'Post')).toThrow(ForbiddenError as unknown as Error)
     })
 
-    it("raises error with context information", () => {
+    it('raises error with context information', () => {
       let thrownError: ForbiddenError<PureAbility> | undefined
       const { error } = setup()
 
       try {
-        error.throwUnlessCan("archive", "Post")
+        error.throwUnlessCan('archive', 'Post')
       } catch (abilityError) {
         thrownError = abilityError as ForbiddenError<PureAbility>
       }
 
-      expect(thrownError!.action).toBe("archive")
-      expect(thrownError!.subject).toBe("Post")
-      expect(thrownError!.subjectType).toBe("Post")
+      expect(thrownError!.action).toBe('archive')
+      expect(thrownError!.subject).toBe('Post')
+      expect(thrownError!.subjectType).toBe('Post')
     })
 
-    it("raises error with message provided in `reason` field of forbidden rule", () => {
-      const NO_CARD_MESSAGE = "No credit card provided"
+    it('raises error with message provided in `reason` field of forbidden rule', () => {
+      const NO_CARD_MESSAGE = 'No credit card provided'
       const { ability, error } = setup()
 
-      ability.update([
-        {
-          action: "update",
-          subject: "Post",
-          inverted: true,
-          reason: NO_CARD_MESSAGE,
-        },
-      ])
+      ability.update([{
+        action: 'update',
+        subject: 'Post',
+        inverted: true,
+        reason: NO_CARD_MESSAGE
+      }])
 
-      expect(() => error.throwUnlessCan("update", "Post")).toThrow(
-        NO_CARD_MESSAGE
-      )
+      expect(() => error.throwUnlessCan('update', 'Post')).toThrow(NO_CARD_MESSAGE)
     })
 
-    it("can raise error with custom message", () => {
-      const message = "My custom error message"
+    it('can raise error with custom message', () => {
+      const message = 'My custom error message'
       const { error } = setup()
 
-      expect(() =>
-        error.setMessage(message).throwUnlessCan("update", "Post")
-      ).toThrow(message)
+      expect(() => error.setMessage(message).throwUnlessCan('update', 'Post')).toThrow(message)
     })
 
-    it("correctly extracts subject type name from class subject types", () => {
+    it('correctly extracts subject type name from class subject types', () => {
       class Post {}
 
-      const ability = new PureAbility([{ action: "read", subject: Post }], {
-        detectSubjectType: (o) => o.constructor as SubjectType,
+      const ability = new PureAbility([
+        { action: 'read', subject: Post }
+      ], {
+        detectSubjectType: o => o.constructor as SubjectType
       })
 
       try {
-        ForbiddenError.from(ability).throwUnlessCan("update", Post)
-        expect("this code").toBe("never reached")
+        ForbiddenError.from(ability).throwUnlessCan('update', Post)
+        expect('this code').toBe('never reached')
       } catch (error) {
-        expect((error as ForbiddenError<PureAbility>).subjectType).toBe("Post")
-        expect((error as ForbiddenError<PureAbility>).message).toBe(
-          'Cannot execute "update" on "Post"'
-        )
+        expect((error as ForbiddenError<PureAbility>).subjectType).toBe('Post')
+        expect((error as ForbiddenError<PureAbility>).message).toBe('Cannot execute "update" on "Post"')
       }
     })
   })
 
-  describe("`setDefaultMessage` method", () => {
+  describe('`setDefaultMessage` method', () => {
     afterEach(() => {
       ForbiddenError.setDefaultMessage(getDefaultErrorMessage)
     })
 
-    it("sets default message from function", () => {
-      ForbiddenError.setDefaultMessage(
-        (err) => `errror -> ${err.action}-${err.subjectType}`
-      )
+    it('sets default message from function', () => {
+      ForbiddenError.setDefaultMessage(err => `errror -> ${err.action}-${err.subjectType}`)
       const { error } = setup()
 
-      expect(() => error.throwUnlessCan("update", "Post")).toThrow(
-        "errror -> update-Post"
-      )
+      expect(() => error.throwUnlessCan('update', 'Post')).toThrow('errror -> update-Post')
     })
   })
 
   function setup() {
-    const ability = new PureAbility([{ action: "read", subject: "Post" }])
+    const ability = new PureAbility([
+      { action: 'read', subject: 'Post' }
+    ])
     const error = ForbiddenError.from(ability)
 
     return { ability, error }

--- a/packages/casl-ability/spec/error.spec.ts
+++ b/packages/casl-ability/spec/error.spec.ts
@@ -1,89 +1,120 @@
-import { ForbiddenError, getDefaultErrorMessage, PureAbility, SubjectType } from '../src'
+import {
+  ForbiddenError,
+  getDefaultErrorMessage,
+  PureAbility,
+  SubjectType,
+} from "../src"
 
-describe('`ForbiddenError` class', () => {
-  describe('`throwUnlessCan` method', () => {
-    it('raises forbidden exception on disallowed action', () => {
+describe("`ForbiddenError` class", () => {
+  describe("`throwUnlessCan` method", () => {
+    it("raises forbidden exception on disallowed action", () => {
       const { error } = setup()
-      expect(() => error.throwUnlessCan('archive', 'Post')).toThrow(ForbiddenError as unknown as Error)
+      expect(() => error.throwUnlessCan("archive", "Post")).toThrow(
+        ForbiddenError as unknown as Error
+      )
     })
 
-    it('does not raise forbidden exception on allowed action', () => {
+    it("does not raise forbidden exception on disallowed action when inverted", () => {
       const { error } = setup()
-      expect(() => error.throwUnlessCan('read', 'Post')).not.toThrow(ForbiddenError as unknown as Error)
+      expect(() => error.throwUnlessCannot("archive", "Post")).not.toThrow(
+        ForbiddenError as unknown as Error
+      )
     })
 
-    it('raises error with context information', () => {
+    it("does not raise forbidden exception on allowed action", () => {
+      const { error } = setup()
+      expect(() => error.throwUnlessCan("read", "Post")).not.toThrow(
+        ForbiddenError as unknown as Error
+      )
+    })
+
+    it("raises forbidden exception on allowed action when inverted", () => {
+      const { error } = setup()
+      expect(() => error.throwUnlessCannot("read", "Post")).toThrow(
+        ForbiddenError as unknown as Error
+      )
+    })
+
+    it("raises error with context information", () => {
       let thrownError: ForbiddenError<PureAbility> | undefined
       const { error } = setup()
 
       try {
-        error.throwUnlessCan('archive', 'Post')
+        error.throwUnlessCan("archive", "Post")
       } catch (abilityError) {
         thrownError = abilityError as ForbiddenError<PureAbility>
       }
 
-      expect(thrownError!.action).toBe('archive')
-      expect(thrownError!.subject).toBe('Post')
-      expect(thrownError!.subjectType).toBe('Post')
+      expect(thrownError!.action).toBe("archive")
+      expect(thrownError!.subject).toBe("Post")
+      expect(thrownError!.subjectType).toBe("Post")
     })
 
-    it('raises error with message provided in `reason` field of forbidden rule', () => {
-      const NO_CARD_MESSAGE = 'No credit card provided'
+    it("raises error with message provided in `reason` field of forbidden rule", () => {
+      const NO_CARD_MESSAGE = "No credit card provided"
       const { ability, error } = setup()
 
-      ability.update([{
-        action: 'update',
-        subject: 'Post',
-        inverted: true,
-        reason: NO_CARD_MESSAGE
-      }])
+      ability.update([
+        {
+          action: "update",
+          subject: "Post",
+          inverted: true,
+          reason: NO_CARD_MESSAGE,
+        },
+      ])
 
-      expect(() => error.throwUnlessCan('update', 'Post')).toThrow(NO_CARD_MESSAGE)
+      expect(() => error.throwUnlessCan("update", "Post")).toThrow(
+        NO_CARD_MESSAGE
+      )
     })
 
-    it('can raise error with custom message', () => {
-      const message = 'My custom error message'
+    it("can raise error with custom message", () => {
+      const message = "My custom error message"
       const { error } = setup()
 
-      expect(() => error.setMessage(message).throwUnlessCan('update', 'Post')).toThrow(message)
+      expect(() =>
+        error.setMessage(message).throwUnlessCan("update", "Post")
+      ).toThrow(message)
     })
 
-    it('correctly extracts subject type name from class subject types', () => {
+    it("correctly extracts subject type name from class subject types", () => {
       class Post {}
 
-      const ability = new PureAbility([
-        { action: 'read', subject: Post }
-      ], {
-        detectSubjectType: o => o.constructor as SubjectType
+      const ability = new PureAbility([{ action: "read", subject: Post }], {
+        detectSubjectType: (o) => o.constructor as SubjectType,
       })
 
       try {
-        ForbiddenError.from(ability).throwUnlessCan('update', Post)
-        expect('this code').toBe('never reached')
+        ForbiddenError.from(ability).throwUnlessCan("update", Post)
+        expect("this code").toBe("never reached")
       } catch (error) {
-        expect((error as ForbiddenError<PureAbility>).subjectType).toBe('Post')
-        expect((error as ForbiddenError<PureAbility>).message).toBe('Cannot execute "update" on "Post"')
+        expect((error as ForbiddenError<PureAbility>).subjectType).toBe("Post")
+        expect((error as ForbiddenError<PureAbility>).message).toBe(
+          'Cannot execute "update" on "Post"'
+        )
       }
     })
   })
 
-  describe('`setDefaultMessage` method', () => {
+  describe("`setDefaultMessage` method", () => {
     afterEach(() => {
       ForbiddenError.setDefaultMessage(getDefaultErrorMessage)
     })
 
-    it('sets default message from function', () => {
-      ForbiddenError.setDefaultMessage(err => `errror -> ${err.action}-${err.subjectType}`)
+    it("sets default message from function", () => {
+      ForbiddenError.setDefaultMessage(
+        (err) => `errror -> ${err.action}-${err.subjectType}`
+      )
       const { error } = setup()
 
-      expect(() => error.throwUnlessCan('update', 'Post')).toThrow('errror -> update-Post')
+      expect(() => error.throwUnlessCan("update", "Post")).toThrow(
+        "errror -> update-Post"
+      )
     })
   })
 
   function setup() {
-    const ability = new PureAbility([
-      { action: 'read', subject: 'Post' }
-    ])
+    const ability = new PureAbility([{ action: "read", subject: "Post" }])
     const error = ForbiddenError.from(ability)
 
     return { ability, error }

--- a/packages/casl-ability/spec/error.spec.ts
+++ b/packages/casl-ability/spec/error.spec.ts
@@ -17,6 +17,36 @@ describe('`ForbiddenError` class', () => {
       expect(() => error.throwUnlessCan('read', 'Post')).not.toThrow(ForbiddenError as unknown as Error)
     })
 
+    it('does not produce error on allowed action', () => {
+      const { error } = setup()
+      expect(error.unlessCan('read', 'Post')).toBeUndefined()
+    })
+
+    it('does not produce error on forbidden action when inverted', () => {
+      const { error } = setup()
+      expect(error.unlessCannot('read', 'Post')).toBeUndefined()
+    })
+
+    it('produces an error on allowed action when inverted', () => {
+      const { error } = setup()
+      expect(error.unlessCannot('read', 'Post')).not.toBeUndefined()
+    })
+
+    it("error is inverted when producing the error via 'unlessCannot'", () => {
+      const { error } = setup()
+      expect(error.unlessCannot('read', 'Post')?.inverted).toBe(true)
+    })
+
+    it("error is not inverted when producing the error via 'unlessCan'", () => {
+      const { error } = setup()
+      expect(error.unlessCan('archive', 'Post')?.inverted).toBe(false)
+    })
+
+    it('produces an error on forbidden action', () => {
+      const { error } = setup()
+      expect(error.unlessCan('archive', 'Post')).not.toBeUndefined()
+    })
+
     it('raises forbidden exception on allowed action when inverted', () => {
       const { error } = setup()
       expect(() => error.throwUnlessCannot('read', 'Post')).toThrow(ForbiddenError as unknown as Error)

--- a/packages/casl-ability/src/ForbiddenError.ts
+++ b/packages/casl-ability/src/ForbiddenError.ts
@@ -56,9 +56,9 @@ export class ForbiddenError<T extends AnyAbility> extends NativeError {
   ): this | undefined {
     const rule = this.ability.relevantRuleFor(action, subject, field);
 
-    if (inverted && (!rule || rule.inverted)) {
-      return;
-    } else if (!inverted && rule && !rule.inverted) {
+    const isRuleInverted = rule?.inverted ?? false;
+
+    if (inverted === isRuleInverted) {
       return;
     }
 

--- a/packages/casl-ability/src/ForbiddenError.ts
+++ b/packages/casl-ability/src/ForbiddenError.ts
@@ -14,6 +14,7 @@ const NativeError = function NError(this: Error, message: string) {
 
 NativeError.prototype = Object.create(Error.prototype);
 
+
 export class ForbiddenError<T extends AnyAbility> extends NativeError {
   public readonly ability!: T;
   public action!: Normalize<Generics<T>["abilities"]>[0];
@@ -79,10 +80,30 @@ export class ForbiddenError<T extends AnyAbility> extends NativeError {
     return this; // eslint-disable-line consistent-return
   }
 
+  private unless(inverted: boolean, ...args: Parameters<T["can"]> ): this | undefined 
+  private unless(
+    inverted: boolean,
+    action: string,
+    subject?: Subject,
+    field?: string
+  ): this | undefined {
+    return this.handleRule(action, inverted, subject, field,);
+  }
+
+  private throwUnless(inverted: boolean, ...args: Parameters<T["can"]> | Parameters<T["cannot"]>): void
+  private throwUnless(
+    inverted: boolean,
+    action: string,
+    subject?: Subject,
+    field?: string
+  ): void {
+    const error = (this as any).unless(inverted, action, subject, field);
+    if (error) throw error;
+  }
+
   throwUnlessCan(...args: Parameters<T["can"]>): void;
   throwUnlessCan(action: string, subject?: Subject, field?: string): void {
-    const error = (this as any).unlessCan(action, subject, field);
-    if (error) throw error;
+    (this as any).throwUnless(false, action, subject, field)
   }
 
   unlessCan(...args: Parameters<T["can"]>): this | undefined;
@@ -91,13 +112,12 @@ export class ForbiddenError<T extends AnyAbility> extends NativeError {
     subject?: Subject,
     field?: string
   ): this | undefined {
-    return this.handleRule(action, false, subject, field);
+    return (this as any).unless(false, action, subject, field);
   }
 
   throwUnlessCannot(...args: Parameters<T["cannot"]>): void;
   throwUnlessCannot(action: string, subject?: Subject, field?: string): void {
-    const error = (this as any).unlessCannot(action, subject, field);
-    if (error) throw error;
+    return (this as any).throwUnless(true, action, subject, field);
   }
 
   unlessCannot(...args: Parameters<T["cannot"]>): this | undefined;
@@ -106,6 +126,6 @@ export class ForbiddenError<T extends AnyAbility> extends NativeError {
     subject?: Subject,
     field?: string
   ): this | undefined {
-    return this.handleRule(action, true, subject, field);
+    return (this as any).unless(true, action, subject, field);
   }
 }

--- a/packages/casl-ability/src/ForbiddenError.ts
+++ b/packages/casl-ability/src/ForbiddenError.ts
@@ -1,11 +1,12 @@
-import { AnyAbility } from './PureAbility';
-import { Normalize, Subject } from './types';
-import { Generics } from './RuleIndex';
-import { getSubjectTypeName } from './utils';
+import { AnyAbility } from "./PureAbility";
+import { Generics } from "./RuleIndex";
+import { Normalize, Subject } from "./types";
+import { getSubjectTypeName } from "./utils";
 
 export type GetErrorMessage = (error: ForbiddenError<AnyAbility>) => string;
 /** @deprecated will be removed in the next major release */
-export const getDefaultErrorMessage: GetErrorMessage = error => `Cannot execute "${error.action}" on "${error.subjectType}"`;
+export const getDefaultErrorMessage: GetErrorMessage = (error) =>
+  `Cannot execute "${error.action}" on "${error.subjectType}"`;
 
 const NativeError = function NError(this: Error, message: string) {
   this.message = message;
@@ -15,15 +16,16 @@ NativeError.prototype = Object.create(Error.prototype);
 
 export class ForbiddenError<T extends AnyAbility> extends NativeError {
   public readonly ability!: T;
-  public action!: Normalize<Generics<T>['abilities']>[0];
-  public subject!: Generics<T>['abilities'][1];
+  public action!: Normalize<Generics<T>["abilities"]>[0];
+  public subject!: Generics<T>["abilities"][1];
   public field?: string;
   public subjectType!: string;
 
   static _defaultErrorMessage = getDefaultErrorMessage;
 
   static setDefaultMessage(messageOrFn: string | GetErrorMessage) {
-    this._defaultErrorMessage = typeof messageOrFn === 'string' ? () => messageOrFn : messageOrFn;
+    this._defaultErrorMessage =
+      typeof messageOrFn === "string" ? () => messageOrFn : messageOrFn;
   }
 
   static from<U extends AnyAbility>(ability: U): ForbiddenError<U> {
@@ -31,11 +33,11 @@ export class ForbiddenError<T extends AnyAbility> extends NativeError {
   }
 
   private constructor(ability: T) {
-    super('');
+    super("");
     this.ability = ability;
 
-    if (typeof Error.captureStackTrace === 'function') {
-      this.name = 'ForbiddenError';
+    if (typeof Error.captureStackTrace === "function") {
+      this.name = "ForbiddenError";
       Error.captureStackTrace(this, this.constructor);
     }
   }
@@ -45,28 +47,63 @@ export class ForbiddenError<T extends AnyAbility> extends NativeError {
     return this;
   }
 
-  throwUnlessCan(...args: Parameters<T['can']>): void;
-  throwUnlessCan(action: string, subject?: Subject, field?: string): void {
-    const error = (this as any).unlessCan(action, subject, field);
-    if (error) throw error;
-  }
-
-  unlessCan(...args: Parameters<T['can']>): this | undefined;
-  unlessCan(action: string, subject?: Subject, field?: string): this | undefined {
+  private handleRule(
+    action: string,
+    subject?: Subject,
+    field?: string,
+    inverted?: boolean
+  ): this | undefined {
     const rule = this.ability.relevantRuleFor(action, subject, field);
 
-    if (rule && !rule.inverted) {
+    if (inverted && (!rule || rule.inverted)) {
+      return;
+    } else if (!inverted && rule && !rule.inverted) {
       return;
     }
 
     this.action = action;
     this.subject = subject;
-    this.subjectType = getSubjectTypeName(this.ability.detectSubjectType(subject));
+    this.subjectType = getSubjectTypeName(
+      this.ability.detectSubjectType(subject)
+    );
     this.field = field;
 
-    const reason = rule ? rule.reason : '';
+    const reason = rule ? rule.reason : "";
     // eslint-disable-next-line no-underscore-dangle
-    this.message = this.message || reason || (this.constructor as any)._defaultErrorMessage(this);
+    this.message =
+      this.message ||
+      reason ||
+      (this.constructor as any)._defaultErrorMessage(this);
     return this; // eslint-disable-line consistent-return
+  }
+
+  throwUnlessCan(...args: Parameters<T["can"]>): void;
+  throwUnlessCan(action: string, subject?: Subject, field?: string): void {
+    const error = (this as any).unlessCan(action, subject, field);
+    if (error) throw error;
+  }
+
+  unlessCan(...args: Parameters<T["can"]>): this | undefined;
+  unlessCan(
+    action: string,
+    subject?: Subject,
+    field?: string
+  ): this | undefined {
+    return this.handleRule(action, subject, field, false);
+  }
+
+  throwUnlessCannot(...args: Parameters<T["cannot"]>): void;
+  throwUnlessCannot(action: string, subject?: Subject, field?: string): void {
+    const error = (this as any).unlessCannot(action, subject, field);
+    if (error) throw error;
+  }
+
+  unlessCannot(...args: Parameters<T["cannot"]>): this | undefined;
+  unlessCannot(
+    action: string,
+    subject?: Subject,
+    field?: string
+  ): this | undefined {
+    return this.handleRule(action, subject, field, true);
   }
 }

--- a/packages/casl-ability/src/ForbiddenError.ts
+++ b/packages/casl-ability/src/ForbiddenError.ts
@@ -56,9 +56,9 @@ export class ForbiddenError<T extends AnyAbility> extends NativeError {
   ): this | undefined {
     const rule = this.ability.relevantRuleFor(action, subject, field);
 
-    const isRuleInverted = rule?.inverted ?? false;
-
-    if (inverted === isRuleInverted) {
+    if (inverted && (!rule || rule.inverted)) {
+      return;
+    } else if (!inverted && rule && !rule.inverted) {
       return;
     }
 

--- a/packages/casl-react/spec/Can.spec.js
+++ b/packages/casl-react/spec/Can.spec.js
@@ -13,7 +13,7 @@ describe('`Can` component', () => {
     ability = defineAbility((can, cannot) => {
       can('read', 'Post')
       cannot('chop', 'Wood').because(cantChopWoodReason)
-    }).update
+    })
     
   })
 
@@ -30,10 +30,11 @@ describe('`Can` component', () => {
   })
 
   it('Does not pass forbidden reason message to "children" function when allowed', () => {
-    renderer.create(e(Can, { not: true, I: 'chop', a: 'Wood', ability }, children))
+    renderer.create(e(Can, { not: true, I: 'chop', a: 'Wood', ability, passThrough: true }, children))
 
     expect(children).to.have.been.called.with.exactly(ability.cannot('chop', 'Wood'), ability, undefined)
   })
+  
 
   it('has public "allowed" property which returns boolean indicating whether children will be rendered', () => {
     const canComponent = renderer.create(e(Can, { I: 'read', a: 'Post', ability }, children))

--- a/packages/casl-react/spec/Can.spec.js
+++ b/packages/casl-react/spec/Can.spec.js
@@ -17,7 +17,8 @@ describe("`Can` component", () => {
 
     expect(children).to.have.been.called.with.exactly(
       ability.can("read", "Post"),
-      ability
+      ability,
+      undefined
     );
   });
 

--- a/packages/casl-react/spec/Can.spec.js
+++ b/packages/casl-react/spec/Can.spec.js
@@ -1,157 +1,121 @@
-import { defineAbility } from "@casl/ability";
-import { createElement as e } from "react";
-import renderer from "react-test-renderer";
-import { Can } from "../src";
+import { defineAbility } from '@casl/ability'
+import { createElement as e } from 'react'
+import renderer from 'react-test-renderer'
+import { Can } from '../src'
 
-describe("`Can` component", () => {
-  let ability;
-  let children;
+describe('`Can` component', () => {
+  let ability
+  let children
 
   beforeEach(() => {
-    children = spy(() => null);
-    ability = defineAbility((can) => can("read", "Post"));
-  });
+    children = spy(() => null)
+    ability = defineAbility(can => can('read', 'Post'))
+  })
 
   it('passes ability check value and instance as arguments to "children" function', () => {
-    renderer.create(e(Can, { I: "read", a: "Post", ability }, children));
+    renderer.create(e(Can, { I: 'read', a: 'Post', ability }, children))
 
-    expect(children).to.have.been.called.with.exactly(
-      ability.can("read", "Post"),
-      ability,
-      undefined
-    );
-  });
+    expect(children).to.have.been.called.with.exactly(ability.can('read', 'Post'), ability)
+  })
 
   it('has public "allowed" property which returns boolean indicating whether children will be rendered', () => {
-    const canComponent = renderer.create(
-      e(Can, { I: "read", a: "Post", ability }, children)
-    );
-    renderer.create(
-      e(Can, { not: true, I: "run", a: "Marathon", ability }, children)
-    );
+    const canComponent = renderer.create(e(Can, { I: 'read', a: 'Post', ability }, children))
+    renderer.create(e(Can, { not: true, I: 'run', a: 'Marathon', ability }, children))
 
-    expect(canComponent.getInstance().allowed).to.equal(
-      ability.can("read", "Post")
-    );
-    expect(canComponent.getInstance().allowed).to.equal(
-      ability.cannot("run", "Marathon")
-    );
-  });
+    expect(canComponent.getInstance().allowed).to.equal(ability.can('read', 'Post'))
+    expect(canComponent.getInstance().allowed).to.equal(ability.cannot('run', 'Marathon'))
+  })
 
-  it("unsubscribes from ability updates when unmounted", () => {
-    const component = renderer.create(
-      e(Can, { I: "read", a: "Post", ability }, children)
-    );
+  it('unsubscribes from ability updates when unmounted', () => {
+    const component = renderer.create(e(Can, { I: 'read', a: 'Post', ability }, children))
 
-    spy.on(ability, "can");
-    component.unmount();
-    ability.update([]);
+    spy.on(ability, 'can')
+    component.unmount()
+    ability.update([])
 
-    expect(ability.can).not.to.have.been.called();
-  });
+    expect(ability.can).not.to.have.been.called()
+  })
 
-  describe("#render", () => {
-    let child;
+  describe('#render', () => {
+    let child
 
     beforeEach(() => {
-      child = e("a", null, "children");
-    });
+      child = e('a', null, 'children')
+    })
 
-    it("renders children if ability allows to perform an action", () => {
+    it('renders children if ability allows to perform an action', () => {
+      const component = renderer.create(e(Can, { I: 'read', a: 'Post', ability }, child))
+
+      expect(component.toJSON().children).to.deep.equal([child.props.children])
+    })
+
+    it('does not render children if ability does not allow to perform an action', () => {
+      const component = renderer.create(e(Can, { I: 'update', a: 'Post', ability }, child))
+
+      expect(component.toJSON()).to.be.null
+    })
+
+    it('does not render children if ability allows to perform an action, but `not` is set to true', () => {
+      const component = renderer.create(e(Can, { not: true, I: 'read', a: 'Post', ability }, child))
+
+      expect(component.toJSON()).to.be.null
+    })
+
+    it('rerenders when ability rules are changed', () => {
+      const component = renderer.create(e(Can, { I: 'read', a: 'Post', ability }, child))
+      ability.update([])
+
+      expect(component.toJSON()).to.be.null
+    })
+
+    it('rerenders when `I` prop is changed', () => {
+      const component = renderer.create(e(Can, { I: 'update', a: 'Post', ability }, child))
+      component.update(e(Can, { I: 'read', a: 'Post', ability }, child))
+
+      expect(component.toJSON().children).to.deep.equal([child.props.children])
+    })
+
+    it('rerenders when `a` or `an` or `this` prop is changed', () => {
+      const component = renderer.create(e(Can, { I: 'read', a: 'User', ability }, child))
+      component.update(e(Can, { I: 'read', a: 'Post', ability }, child))
+
+      expect(component.toJSON().children).to.deep.equal([child.props.children])
+    })
+
+    it('rerenders when `not` prop is changed', () => {
+      const component = renderer.create(e(Can, { not: true, I: 'read', a: 'Post', ability }, child))
+      component.update(e(Can, { not: false, I: 'read', a: 'Post', ability }, child))
+
+      expect(component.toJSON().children).to.deep.equal([child.props.children])
+    })
+
+    it('does not rerender itself when previous ability rules are changed', () => {
+      const component = renderer.create(e(Can, { I: 'read', a: 'Post', ability }, child))
+      const anotherAbility = defineAbility(can => can('manage', 'Post'))
+
+      component.update(e(Can, { I: 'read', a: 'Post', ability: anotherAbility }, child))
+      ability.update([])
+
+      expect(component.toJSON().children).to.deep.equal([child.props.children])
+    })
+
+    it('can render multiple children if `React.Fragment` is available', () => {
+      const localChildren = [child, e('h1', null, 'another children')]
       const component = renderer.create(
-        e(Can, { I: "read", a: "Post", ability }, child)
-      );
+        e(Can, { I: 'read', a: 'Post', ability }, ...localChildren)
+      )
+      const renderedChildren = localChildren.map(element => renderer.create(element).toJSON())
 
-      expect(component.toJSON().children).to.deep.equal([child.props.children]);
-    });
+      expect(component.toJSON()).to.deep.equal(renderedChildren)
+    })
 
-    it("does not render children if ability does not allow to perform an action", () => {
+    it('always renders children if `passThrough` prop is `true`', () => {
       const component = renderer.create(
-        e(Can, { I: "update", a: "Post", ability }, child)
-      );
+        e(Can, { I: 'delete', a: 'Post', passThrough: true, ability }, child)
+      )
 
-      expect(component.toJSON()).to.be.null;
-    });
-
-    it("does not render children if ability allows to perform an action, but `not` is set to true", () => {
-      const component = renderer.create(
-        e(Can, { not: true, I: "read", a: "Post", ability }, child)
-      );
-
-      expect(component.toJSON()).to.be.null;
-    });
-
-    it("rerenders when ability rules are changed", () => {
-      const component = renderer.create(
-        e(Can, { I: "read", a: "Post", ability }, child)
-      );
-      ability.update([]);
-
-      expect(component.toJSON()).to.be.null;
-    });
-
-    it("rerenders when `I` prop is changed", () => {
-      const component = renderer.create(
-        e(Can, { I: "update", a: "Post", ability }, child)
-      );
-      component.update(e(Can, { I: "read", a: "Post", ability }, child));
-
-      expect(component.toJSON().children).to.deep.equal([child.props.children]);
-    });
-
-    it("rerenders when `a` or `an` or `this` prop is changed", () => {
-      const component = renderer.create(
-        e(Can, { I: "read", a: "User", ability }, child)
-      );
-      component.update(e(Can, { I: "read", a: "Post", ability }, child));
-
-      expect(component.toJSON().children).to.deep.equal([child.props.children]);
-    });
-
-    it("rerenders when `not` prop is changed", () => {
-      const component = renderer.create(
-        e(Can, { not: true, I: "read", a: "Post", ability }, child)
-      );
-      component.update(
-        e(Can, { not: false, I: "read", a: "Post", ability }, child)
-      );
-
-      expect(component.toJSON().children).to.deep.equal([child.props.children]);
-    });
-
-    it("does not rerender itself when previous ability rules are changed", () => {
-      const component = renderer.create(
-        e(Can, { I: "read", a: "Post", ability }, child)
-      );
-      const anotherAbility = defineAbility((can) => can("manage", "Post"));
-
-      component.update(
-        e(Can, { I: "read", a: "Post", ability: anotherAbility }, child)
-      );
-      ability.update([]);
-
-      expect(component.toJSON().children).to.deep.equal([child.props.children]);
-    });
-
-    it("can render multiple children if `React.Fragment` is available", () => {
-      const localChildren = [child, e("h1", null, "another children")];
-      const component = renderer.create(
-        e(Can, { I: "read", a: "Post", ability }, ...localChildren)
-      );
-      const renderedChildren = localChildren.map((element) =>
-        renderer.create(element).toJSON()
-      );
-
-      expect(component.toJSON()).to.deep.equal(renderedChildren);
-    });
-
-    it("always renders children if `passThrough` prop is `true`", () => {
-      const component = renderer.create(
-        e(Can, { I: "delete", a: "Post", passThrough: true, ability }, child)
-      );
-
-      expect(ability.can("delete", "Post")).to.be.false;
-      expect(component.toJSON().children).to.deep.equal([child.props.children]);
-    });
-  });
-});
+      expect(ability.can('delete', 'Post')).to.be.false
+      expect(component.toJSON().children).to.deep.equal([child.props.children])
+    })
+  })
+})

--- a/packages/casl-react/spec/Can.spec.js
+++ b/packages/casl-react/spec/Can.spec.js
@@ -1,121 +1,156 @@
-import { createElement as e } from 'react'
-import { defineAbility } from '@casl/ability'
-import renderer from 'react-test-renderer'
-import { Can } from '../src'
+import { defineAbility } from "@casl/ability";
+import { createElement as e } from "react";
+import renderer from "react-test-renderer";
+import { Can } from "../src";
 
-describe('`Can` component', () => {
-  let ability
-  let children
+describe("`Can` component", () => {
+  let ability;
+  let children;
 
   beforeEach(() => {
-    children = spy(() => null)
-    ability = defineAbility(can => can('read', 'Post'))
-  })
+    children = spy(() => null);
+    ability = defineAbility((can) => can("read", "Post"));
+  });
 
   it('passes ability check value and instance as arguments to "children" function', () => {
-    renderer.create(e(Can, { I: 'read', a: 'Post', ability }, children))
+    renderer.create(e(Can, { I: "read", a: "Post", ability }, children));
 
-    expect(children).to.have.been.called.with.exactly(ability.can('read', 'Post'), ability)
-  })
+    expect(children).to.have.been.called.with.exactly(
+      ability.can("read", "Post"),
+      ability
+    );
+  });
 
   it('has public "allowed" property which returns boolean indicating whether children will be rendered', () => {
-    const canComponent = renderer.create(e(Can, { I: 'read', a: 'Post', ability }, children))
-    renderer.create(e(Can, { not: true, I: 'run', a: 'Marathon', ability }, children))
+    const canComponent = renderer.create(
+      e(Can, { I: "read", a: "Post", ability }, children)
+    );
+    renderer.create(
+      e(Can, { not: true, I: "run", a: "Marathon", ability }, children)
+    );
 
-    expect(canComponent.getInstance().allowed).to.equal(ability.can('read', 'Post'))
-    expect(canComponent.getInstance().allowed).to.equal(ability.cannot('run', 'Marathon'))
-  })
+    expect(canComponent.getInstance().allowed).to.equal(
+      ability.can("read", "Post")
+    );
+    expect(canComponent.getInstance().allowed).to.equal(
+      ability.cannot("run", "Marathon")
+    );
+  });
 
-  it('unsubscribes from ability updates when unmounted', () => {
-    const component = renderer.create(e(Can, { I: 'read', a: 'Post', ability }, children))
+  it("unsubscribes from ability updates when unmounted", () => {
+    const component = renderer.create(
+      e(Can, { I: "read", a: "Post", ability }, children)
+    );
 
-    spy.on(ability, 'can')
-    component.unmount()
-    ability.update([])
+    spy.on(ability, "can");
+    component.unmount();
+    ability.update([]);
 
-    expect(ability.can).not.to.have.been.called()
-  })
+    expect(ability.can).not.to.have.been.called();
+  });
 
-  describe('#render', () => {
-    let child
+  describe("#render", () => {
+    let child;
 
     beforeEach(() => {
-      child = e('a', null, 'children')
-    })
+      child = e("a", null, "children");
+    });
 
-    it('renders children if ability allows to perform an action', () => {
-      const component = renderer.create(e(Can, { I: 'read', a: 'Post', ability }, child))
-
-      expect(component.toJSON().children).to.deep.equal([child.props.children])
-    })
-
-    it('does not render children if ability does not allow to perform an action', () => {
-      const component = renderer.create(e(Can, { I: 'update', a: 'Post', ability }, child))
-
-      expect(component.toJSON()).to.be.null
-    })
-
-    it('does not render children if ability allows to perform an action, but `not` is set to true', () => {
-      const component = renderer.create(e(Can, { not: true, I: 'read', a: 'Post', ability }, child))
-
-      expect(component.toJSON()).to.be.null
-    })
-
-    it('rerenders when ability rules are changed', () => {
-      const component = renderer.create(e(Can, { I: 'read', a: 'Post', ability }, child))
-      ability.update([])
-
-      expect(component.toJSON()).to.be.null
-    })
-
-    it('rerenders when `I` prop is changed', () => {
-      const component = renderer.create(e(Can, { I: 'update', a: 'Post', ability }, child))
-      component.update(e(Can, { I: 'read', a: 'Post', ability }, child))
-
-      expect(component.toJSON().children).to.deep.equal([child.props.children])
-    })
-
-    it('rerenders when `a` or `an` or `this` prop is changed', () => {
-      const component = renderer.create(e(Can, { I: 'read', a: 'User', ability }, child))
-      component.update(e(Can, { I: 'read', a: 'Post', ability }, child))
-
-      expect(component.toJSON().children).to.deep.equal([child.props.children])
-    })
-
-    it('rerenders when `not` prop is changed', () => {
-      const component = renderer.create(e(Can, { not: true, I: 'read', a: 'Post', ability }, child))
-      component.update(e(Can, { not: false, I: 'read', a: 'Post', ability }, child))
-
-      expect(component.toJSON().children).to.deep.equal([child.props.children])
-    })
-
-    it('does not rerender itself when previous ability rules are changed', () => {
-      const component = renderer.create(e(Can, { I: 'read', a: 'Post', ability }, child))
-      const anotherAbility = defineAbility(can => can('manage', 'Post'))
-
-      component.update(e(Can, { I: 'read', a: 'Post', ability: anotherAbility }, child))
-      ability.update([])
-
-      expect(component.toJSON().children).to.deep.equal([child.props.children])
-    })
-
-    it('can render multiple children if `React.Fragment` is available', () => {
-      const localChildren = [child, e('h1', null, 'another children')]
+    it("renders children if ability allows to perform an action", () => {
       const component = renderer.create(
-        e(Can, { I: 'read', a: 'Post', ability }, ...localChildren)
-      )
-      const renderedChildren = localChildren.map(element => renderer.create(element).toJSON())
+        e(Can, { I: "read", a: "Post", ability }, child)
+      );
 
-      expect(component.toJSON()).to.deep.equal(renderedChildren)
-    })
+      expect(component.toJSON().children).to.deep.equal([child.props.children]);
+    });
 
-    it('always renders children if `passThrough` prop is `true`', () => {
+    it("does not render children if ability does not allow to perform an action", () => {
       const component = renderer.create(
-        e(Can, { I: 'delete', a: 'Post', passThrough: true, ability }, child)
-      )
+        e(Can, { I: "update", a: "Post", ability }, child)
+      );
 
-      expect(ability.can('delete', 'Post')).to.be.false
-      expect(component.toJSON().children).to.deep.equal([child.props.children])
-    })
-  })
-})
+      expect(component.toJSON()).to.be.null;
+    });
+
+    it("does not render children if ability allows to perform an action, but `not` is set to true", () => {
+      const component = renderer.create(
+        e(Can, { not: true, I: "read", a: "Post", ability }, child)
+      );
+
+      expect(component.toJSON()).to.be.null;
+    });
+
+    it("rerenders when ability rules are changed", () => {
+      const component = renderer.create(
+        e(Can, { I: "read", a: "Post", ability }, child)
+      );
+      ability.update([]);
+
+      expect(component.toJSON()).to.be.null;
+    });
+
+    it("rerenders when `I` prop is changed", () => {
+      const component = renderer.create(
+        e(Can, { I: "update", a: "Post", ability }, child)
+      );
+      component.update(e(Can, { I: "read", a: "Post", ability }, child));
+
+      expect(component.toJSON().children).to.deep.equal([child.props.children]);
+    });
+
+    it("rerenders when `a` or `an` or `this` prop is changed", () => {
+      const component = renderer.create(
+        e(Can, { I: "read", a: "User", ability }, child)
+      );
+      component.update(e(Can, { I: "read", a: "Post", ability }, child));
+
+      expect(component.toJSON().children).to.deep.equal([child.props.children]);
+    });
+
+    it("rerenders when `not` prop is changed", () => {
+      const component = renderer.create(
+        e(Can, { not: true, I: "read", a: "Post", ability }, child)
+      );
+      component.update(
+        e(Can, { not: false, I: "read", a: "Post", ability }, child)
+      );
+
+      expect(component.toJSON().children).to.deep.equal([child.props.children]);
+    });
+
+    it("does not rerender itself when previous ability rules are changed", () => {
+      const component = renderer.create(
+        e(Can, { I: "read", a: "Post", ability }, child)
+      );
+      const anotherAbility = defineAbility((can) => can("manage", "Post"));
+
+      component.update(
+        e(Can, { I: "read", a: "Post", ability: anotherAbility }, child)
+      );
+      ability.update([]);
+
+      expect(component.toJSON().children).to.deep.equal([child.props.children]);
+    });
+
+    it("can render multiple children if `React.Fragment` is available", () => {
+      const localChildren = [child, e("h1", null, "another children")];
+      const component = renderer.create(
+        e(Can, { I: "read", a: "Post", ability }, ...localChildren)
+      );
+      const renderedChildren = localChildren.map((element) =>
+        renderer.create(element).toJSON()
+      );
+
+      expect(component.toJSON()).to.deep.equal(renderedChildren);
+    });
+
+    it("always renders children if `passThrough` prop is `true`", () => {
+      const component = renderer.create(
+        e(Can, { I: "delete", a: "Post", passThrough: true, ability }, child)
+      );
+
+      expect(ability.can("delete", "Post")).to.be.false;
+      expect(component.toJSON().children).to.deep.equal([child.props.children]);
+    });
+  });
+});

--- a/packages/casl-react/spec/Can.spec.js
+++ b/packages/casl-react/spec/Can.spec.js
@@ -1,4 +1,4 @@
-import { defineAbility } from '@casl/ability'
+import { defineAbility, ForbiddenError } from '@casl/ability'
 import { createElement as e } from 'react'
 import renderer from 'react-test-renderer'
 import { Can } from '../src'
@@ -15,7 +15,7 @@ describe('`Can` component', () => {
   it('passes ability check value and instance as arguments to "children" function', () => {
     renderer.create(e(Can, { I: 'read', a: 'Post', ability }, children))
 
-    expect(children).to.have.been.called.with.exactly(ability.can('read', 'Post'), ability)
+    expect(children).to.have.been.called.with.exactly(ability.can('read', 'Post'), ability, undefined)
   })
 
   it('has public "allowed" property which returns boolean indicating whether children will be rendered', () => {
@@ -24,6 +24,14 @@ describe('`Can` component', () => {
 
     expect(canComponent.getInstance().allowed).to.equal(ability.can('read', 'Post'))
     expect(canComponent.getInstance().allowed).to.equal(ability.cannot('run', 'Marathon'))
+  })
+
+  it('has public "forbiddenReason" property which returns the message for ForbiddenError ', () => {
+    const canComponent = renderer.create(e(Can, { I: 'read', a: 'Post', ability }, children))
+    renderer.create(e(Can, {  not: true, I: 'run', a: 'Marathon', ability }, children))
+
+    expect(canComponent.getInstance().forbiddenReason).to.equal(ForbiddenError.from(ability).unlessCan('read', 'Post')?.message)
+    expect(canComponent.getInstance().forbiddenReason).to.equal(ForbiddenError.from(ability).unlessCannot('run', 'Marathon')?.message)
   })
 
   it('unsubscribes from ability updates when unmounted', () => {

--- a/packages/casl-react/spec/Can.spec.js
+++ b/packages/casl-react/spec/Can.spec.js
@@ -6,16 +6,33 @@ import { Can } from '../src'
 describe('`Can` component', () => {
   let ability
   let children
+  let cantChopWoodReason = 'You are not a lumberjack'
 
   beforeEach(() => {
     children = spy(() => null)
-    ability = defineAbility(can => can('read', 'Post'))
+    ability = defineAbility((can, cannot) => {
+      can('read', 'Post')
+      cannot('chop', 'Wood').because(cantChopWoodReason)
+    }).update
+    
   })
 
   it('passes ability check value and instance as arguments to "children" function', () => {
     renderer.create(e(Can, { I: 'read', a: 'Post', ability }, children))
 
     expect(children).to.have.been.called.with.exactly(ability.can('read', 'Post'), ability, undefined)
+  })
+
+  it('passes forbidden reason message to "children" function when not allowed', () => {
+
+    renderer.create(e(Can, { I: 'chop', a: 'Wood', ability, passThrough: true }, children))
+    expect(children).to.have.been.called.with.exactly(ability.can('chop', 'Wood'), ability, ForbiddenError.from(ability).unlessCan('chop', 'Wood')?.message)
+  })
+
+  it('Does not pass forbidden reason message to "children" function when allowed', () => {
+    renderer.create(e(Can, { not: true, I: 'chop', a: 'Wood', ability }, children))
+
+    expect(children).to.have.been.called.with.exactly(ability.cannot('chop', 'Wood'), ability, undefined)
   })
 
   it('has public "allowed" property which returns boolean indicating whether children will be rendered', () => {

--- a/packages/casl-react/src/Can.ts
+++ b/packages/casl-react/src/Can.ts
@@ -1,13 +1,14 @@
-import { PureComponent, ReactNode } from 'react';
 import {
-  Unsubscribe,
-  AbilityTuple,
-  SubjectType,
-  AnyAbility,
-  Generics,
   Abilities,
+  AbilityTuple,
+  AnyAbility,
+  ForbiddenError,
+  Generics,
   IfString,
-} from '@casl/ability';
+  SubjectType,
+  Unsubscribe,
+} from "@casl/ability";
+import { PureComponent, ReactNode } from "react";
 
 const noop = () => {};
 
@@ -15,31 +16,50 @@ type AbilityCanProps<
   T extends Abilities,
   Else = IfString<T, { do: T } | { I: T }>
 > = T extends AbilityTuple
-  ? { do: T[0], on: T[1], field?: string } |
-  { I: T[0], a: Extract<T[1], SubjectType>, field?: string } |
-  { I: T[0], an: Extract<T[1], SubjectType>, field?: string } |
-  { I: T[0], this: Exclude<T[1], SubjectType>, field?: string }
+  ?
+      | { do: T[0]; on: T[1]; field?: string }
+      | { I: T[0]; a: Extract<T[1], SubjectType>; field?: string }
+      | { I: T[0]; an: Extract<T[1], SubjectType>; field?: string }
+      | { I: T[0]; this: Exclude<T[1], SubjectType>; field?: string }
   : Else;
 
 interface ExtraProps {
-  not?: boolean
-  passThrough?: boolean
+  not?: boolean;
+  passThrough?: boolean;
 }
 
+type RenderChildrenParameters<T extends AnyAbility> =
+  | [allowed: true, ability: T, forbiddenReason: undefined]
+  | [allowed: false, ability: T, forbiddenReason: string];
+
 interface CanExtraProps<T extends AnyAbility> extends ExtraProps {
-  ability: T
-  children: ReactNode | ((isAllowed: boolean, ability: T) => ReactNode)
+  ability: T;
+  children: ReactNode | ((...args: RenderChildrenParameters<T>) => ReactNode);
 }
 
 interface BoundCanExtraProps<T extends AnyAbility> extends ExtraProps {
-  ability?: T
-  children: ReactNode | ((isAllowed: boolean, ability: T) => ReactNode)
+  ability?: T;
+  children: ReactNode | ((...args: RenderChildrenParameters<T>) => ReactNode);
 }
 
-export type CanProps<T extends AnyAbility> =
-  AbilityCanProps<Generics<T>['abilities']> & CanExtraProps<T>;
-export type BoundCanProps<T extends AnyAbility> =
-  AbilityCanProps<Generics<T>['abilities']> & BoundCanExtraProps<T>;
+type CanRenderWithReason =
+  | {
+      allowed: true;
+      forbiddenReason: undefined;
+    }
+  | {
+      allowed: false;
+      forbiddenReason: string;
+    };
+
+export type CanProps<T extends AnyAbility> = AbilityCanProps<
+  Generics<T>["abilities"]
+> &
+  CanExtraProps<T>;
+export type BoundCanProps<T extends AnyAbility> = AbilityCanProps<
+  Generics<T>["abilities"]
+> &
+  BoundCanExtraProps<T>;
 
 export class Can<
   T extends AnyAbility,
@@ -47,6 +67,7 @@ export class Can<
 > extends PureComponent<IsBound extends true ? BoundCanProps<T> : CanProps<T>> {
   private _isAllowed: boolean = false;
   private _ability: T | null = null;
+  private _forbiddenReason: string | undefined = undefined;
   private _unsubscribeFromAbility: Unsubscribe = noop;
 
   componentWillUnmount() {
@@ -60,10 +81,13 @@ export class Can<
 
     this._unsubscribeFromAbility();
     this._ability = null;
+    this._forbiddenReason = undefined;
 
     if (ability) {
       this._ability = ability;
-      this._unsubscribeFromAbility = ability.on('updated', () => this.forceUpdate());
+      this._unsubscribeFromAbility = ability.on("updated", () =>
+        this.forceUpdate()
+      );
     }
   }
 
@@ -71,25 +95,51 @@ export class Can<
     return this._isAllowed;
   }
 
-  private _canRender(): boolean {
+  private _getCanRenderWithReason(): CanRenderWithReason {
     const props: any = this.props;
     const subject = props.of || props.a || props.an || props.this || props.on;
-    const can = props.not ? 'cannot' : 'can';
+    const check = props.not ? "cannot" : "can";
 
-    return props.ability[can](props.I || props.do, subject, props.field);
+    const args = [props.I || props.do, subject, props.field];
+    const error =
+      check === "can"
+        ? ForbiddenError.from(props.ability!).unlessCan(args)
+        : ForbiddenError.from(props.ability!).unlessCannot(args);
+
+    if (error) {
+      return {
+        allowed: false,
+        forbiddenReason: error.message,
+      };
+    } else {
+      return {
+        allowed: true,
+        forbiddenReason: undefined,
+      };
+    }
   }
 
   render() {
     this._connectToAbility(this.props.ability);
-    this._isAllowed = this._canRender();
-    return this.props.passThrough || this._isAllowed ? this._renderChildren() : null;
+    const { allowed, forbiddenReason } = this._getCanRenderWithReason();
+    this._isAllowed = allowed;
+    this._forbiddenReason = forbiddenReason;
+    return this.props.passThrough || this._isAllowed
+      ? this._renderChildren()
+      : null;
   }
 
   private _renderChildren() {
     const { children, ability } = this.props;
-    const elements = typeof children === 'function'
-      ? children(this._isAllowed, ability as any)
-      : children;
+
+    const args = [
+      this._isAllowed,
+      ability as any,
+      this._forbiddenReason,
+    ] as RenderChildrenParameters<T>;
+
+    const elements =
+      typeof children === "function" ? children(...args) : children;
 
     return elements as ReactNode;
   }

--- a/packages/casl-react/src/Can.ts
+++ b/packages/casl-react/src/Can.ts
@@ -103,8 +103,8 @@ export class Can<
     const args = [props.I || props.do, subject, props.field];
     const error =
       check === "can"
-        ? ForbiddenError.from(props.ability!).unlessCan(args)
-        : ForbiddenError.from(props.ability!).unlessCannot(args);
+        ? ForbiddenError.from(props.ability!).unlessCan(...args)
+        : ForbiddenError.from(props.ability!).unlessCannot(...args);
 
     if (error) {
       return {

--- a/packages/casl-react/src/Can.ts
+++ b/packages/casl-react/src/Can.ts
@@ -95,6 +95,10 @@ export class Can<
     return this._isAllowed;
   }
 
+  get forbiddenReason() {
+    return this._forbiddenReason;
+  }
+
   private _getCanRenderWithReason(): CanRenderWithReason {
     const props: any = this.props;
     const subject = props.of || props.a || props.an || props.this || props.on;
@@ -103,8 +107,8 @@ export class Can<
     const args = [props.I || props.do, subject, props.field];
     const error =
       check === "can"
-        ? ForbiddenError.from(props.ability!).unlessCan(...args)
-        : ForbiddenError.from(props.ability!).unlessCannot(...args);
+        ? ForbiddenError.from(props.ability).unlessCan(...args)
+        : ForbiddenError.from(props.ability).unlessCannot(...args);
 
     if (error) {
       return {

--- a/packages/casl-react/src/factory.ts
+++ b/packages/casl-react/src/factory.ts
@@ -11,7 +11,6 @@ export function createCanBoundTo<T extends AnyAbility>(ability: T): BoundCanClas
     static defaultProps = { ability } as BoundCanClass<T>['defaultProps'];
   };
 }
-console.log('trigger')
 
 export function createContextualCan<T extends AnyAbility>(
   Getter: Consumer<T>

--- a/packages/casl-react/src/factory.ts
+++ b/packages/casl-react/src/factory.ts
@@ -1,6 +1,6 @@
+import { createElement as h, ComponentClass, Consumer, FunctionComponent } from 'react';
 import { AnyAbility } from '@casl/ability';
-import { ComponentClass, Consumer, FunctionComponent, createElement as h } from 'react';
-import { BoundCanProps, Can } from './Can';
+import { Can, BoundCanProps } from './Can';
 
 interface BoundCanClass<T extends AnyAbility> extends ComponentClass<BoundCanProps<T>> {
   new (props: BoundCanProps<T>, context?: any): Can<T, true>

--- a/packages/casl-react/src/factory.ts
+++ b/packages/casl-react/src/factory.ts
@@ -1,6 +1,6 @@
-import { createElement as h, ComponentClass, Consumer, FunctionComponent } from 'react';
 import { AnyAbility } from '@casl/ability';
-import { Can, BoundCanProps } from './Can';
+import { ComponentClass, Consumer, FunctionComponent, createElement as h } from 'react';
+import { BoundCanProps, Can } from './Can';
 
 interface BoundCanClass<T extends AnyAbility> extends ComponentClass<BoundCanProps<T>> {
   new (props: BoundCanProps<T>, context?: any): Can<T, true>
@@ -11,6 +11,7 @@ export function createCanBoundTo<T extends AnyAbility>(ability: T): BoundCanClas
     static defaultProps = { ability } as BoundCanClass<T>['defaultProps'];
   };
 }
+console.log('trigger')
 
 export function createContextualCan<T extends AnyAbility>(
   Getter: Consumer<T>


### PR DESCRIPTION
Addresses #972 


- Passes a third `forbiddenReason` to the `Can` child render function to facilitate displaying reasons in the UI without having to repeat condition checking.
- Adds `throwUnlessCannot` and `unlessCannot` functions to `ForbiddenError` to facilitate logic and provide a mirror for the `cannot` circumstance
- Adds a public `inverted` field to indicate whether the error was produced via `unlessCan` or `unlessCannot`. `inverted` is true when the error was produced via `unlessCannot` similar to how `ability.cannot()` rules are inverted.
