### PR TITLE
Allow arrow functions for ability factory arguments to AbilityBuilder

### DIFF
--- a/packages/casl-ability/spec/builder.spec.js
+++ b/packages/casl-ability/spec/builder.spec.js
@@ -114,6 +114,17 @@ describe('AbilityBuilder', () => {
     expect(factory).to.have.been.called.with(rules, options)
   })
 
+  it('can create Ability instance from a factory arrow function', () => {
+    const factorySpy = spy()
+    const factory = (...args) => factorySpy(...args)
+    const { can, build, rules } = new AbilityBuilder(factory)
+    const options = {}
+    can('read', 'Post')
+    build(options)
+
+    expect(factorySpy).to.have.been.called.with(rules, options)
+  })
+
   describe('defineAbility', () => {
     it('defines `Ability` instance using DSL', () => {
       const ability = defineAbility((can, cannot) => {

--- a/packages/casl-ability/src/AbilityBuilder.ts
+++ b/packages/casl-ability/src/AbilityBuilder.ts
@@ -8,7 +8,7 @@ import {
 } from './types';
 
 function isAbilityClass(factory: AbilityFactory<any>): factory is AnyClass {
-  return typeof factory.prototype.possibleRulesFor === 'function';
+  return factory.prototype !== undefined && typeof factory.prototype.possibleRulesFor === 'function';
 }
 
 class RuleBuilder<T extends AnyAbility> {


### PR DESCRIPTION
Fixes https://github.com/stalniy/casl/issues/981