### PR TITLE
chore(deps): fix angular v19 standalone default

### DIFF
--- a/packages/casl-angular/src/pipes.ts
+++ b/packages/casl-angular/src/pipes.ts
@@ -2,7 +2,7 @@ import { Pipe, Inject, PipeTransform } from '@angular/core';
 import { PureAbility, AnyAbility } from '@casl/ability';
 import { Observable } from 'rxjs';
 
-@Pipe({ name: 'able', pure: false })
+@Pipe({ name: 'able', pure: false, standalone: false })
 export class AblePipe<T extends AnyAbility> implements PipeTransform {
   private _ability: T;
 
@@ -15,7 +15,7 @@ export class AblePipe<T extends AnyAbility> implements PipeTransform {
   }
 }
 
-@Pipe({ name: 'ablePure' })
+@Pipe({ name: 'ablePure', standalone: false })
 export class AblePurePipe<T extends AnyAbility> implements PipeTransform {
   private _ability: T;
 


### PR DESCRIPTION
Angular v19 defaults to standalone for pipes. This change declares them as standalone false.  This does not resolve the long term chore of migrating to standalone and providing in non-module base manner.  E.g., `provideCasl()`

This should allow the existing bot PR of https://github.com/stalniy/casl/pull/988 to build.  When merged will resolve https://github.com/stalniy/casl/issues/1002.