### PR TITLE
docs: make clear that the spread operator example is a bad idea

### DIFF
--- a/packages/casl-mongoose/README.md
+++ b/packages/casl-mongoose/README.md
@@ -63,8 +63,10 @@ posts = await db.collection('posts').find({
 // returns { authorId: 1 }
 const permissionRestrictedConditions = accessibleBy(ability, 'update').ofType('Post');
 
+// DANGER DO NOT DO THIS (see above use $and)
 const query = {
-  ...permissionRestrictedConditions,
+  // This is bad and potentially wrong code
+  ...permissionRestrictedConditions, 
   authorId: 2
 };
 ```


### PR DESCRIPTION
I almost copied the wrong code, because the example is not clearly marked as wrong code