### PR TITLE
feat(generic-typing): change typing to get generic

### DIFF
--- a/packages/casl-prisma/src/index.ts
+++ b/packages/casl-prisma/src/index.ts
@@ -1,18 +1,24 @@
 import { AbilityOptions, AbilityTuple, fieldPatternMatcher, PureAbility, RawRuleFrom } from '@casl/ability';
 import { createAbilityFactory, createAccessibleByFactory, prismaQuery } from './runtime';
-import type { WhereInputPerModel, ModelName, PrismaQuery } from './prismaClientBoundTypes';
+import type { WhereInputPerModel, PrismaQuery } from './prismaClientBoundTypes';
 
 export type { PrismaQuery, WhereInput } from './prismaClientBoundTypes';
 export type { Model, Subjects } from './runtime';
 export { prismaQuery, ParsingQueryError } from './runtime';
 
-const createPrismaAbility = createAbilityFactory<ModelName, PrismaQuery>();
-const accessibleBy = createAccessibleByFactory<WhereInputPerModel, PrismaQuery>();
-
-export {
-  createPrismaAbility,
-  accessibleBy,
+const createPrismaAbility = createAbilityFactory<string, PrismaQuery>();
+const accessibleBy = <TModelName extends string = string, TPrismaClient = any>(
+  ability: PureAbility<any, PrismaQuery<TModelName, TPrismaClient>>,
+  action?: string
+): WhereInputPerModel<TModelName, TPrismaClient> => {
+  const factory = createAccessibleByFactory<
+    WhereInputPerModel<TModelName, TPrismaClient>,
+    PrismaQuery<TModelName, TPrismaClient>
+  >();
+  return factory(ability, action);
 };
+
+export { createPrismaAbility, accessibleBy };
 
 /**
  * Uses conditional type to support union distribution
@@ -25,7 +31,7 @@ type ExtendedAbilityTuple<T extends AbilityTuple> = T extends AbilityTuple
  * @deprecated use createPrismaAbility instead
  */
 export class PrismaAbility<
-  A extends AbilityTuple = [string, ModelName],
+  A extends AbilityTuple = [string, string],
   C extends PrismaQuery = PrismaQuery
 > extends PureAbility<ExtendedAbilityTuple<A>, C> {
   constructor(

--- a/packages/casl-prisma/src/prismaClientBoundTypes.ts
+++ b/packages/casl-prisma/src/prismaClientBoundTypes.ts
@@ -2,27 +2,37 @@ import type { Prisma, PrismaClient } from '@prisma/client';
 import type { hkt } from '@casl/ability';
 import type { ExtractModelName, Model } from './prisma/prismaQuery';
 
-export type ModelName = Prisma.ModelName;
-
-type ModelWhereInput = {
-  [K in Prisma.ModelName]: Uncapitalize<K> extends keyof PrismaClient
-    ? Extract<Parameters<PrismaClient[Uncapitalize<K>]['findFirst']>[0], { where?: any }>['where']
-    : never
+type ModelWhereInput<TModelName extends string, TPrismaClient> = {
+  [K in TModelName]: Uncapitalize<K> extends keyof TPrismaClient
+    ? TPrismaClient[Uncapitalize<K>] extends {
+        findFirst: (...args: any) => any;
+      }
+      ? Extract<
+          Parameters<TPrismaClient[Uncapitalize<K>]['findFirst']>[0],
+          { where?: any }
+        >['where']
+      : never
+    : never;
 };
 
-export type WhereInput<TModelName extends Prisma.ModelName> = Extract<
-ModelWhereInput[TModelName],
-Record<any, any>
+export type WhereInput<TModelName extends string, TPrismaClient> = Extract<
+  ModelWhereInput<TModelName, TPrismaClient>[TModelName],
+  Record<any, any>
 >;
 
-interface PrismaQueryTypeFactory extends hkt.GenericFactory {
-  produce: WhereInput<ExtractModelName<this[0], ModelName>>
+interface PrismaQueryTypeFactory<TModelName extends string, TPrismaClient>
+  extends hkt.GenericFactory {
+  produce: WhereInput<ExtractModelName<this[0], TModelName>, TPrismaClient>;
 }
 
 type PrismaModel = Model<Record<string, any>, string>;
-export type PrismaQuery<T = PrismaModel> =
-    WhereInput<ExtractModelName<T, ModelName>> & hkt.Container<PrismaQueryTypeFactory>;
+export type PrismaQuery<
+  TModelName extends string = Prisma.ModelName,
+  TPrismaClient = PrismaClient,
+  T = PrismaModel
+> = WhereInput<ExtractModelName<T, TModelName>, TPrismaClient> &
+  hkt.Container<PrismaQueryTypeFactory<TModelName, TPrismaClient>>;
 
-export type WhereInputPerModel = {
-  [K in ModelName]: WhereInput<K>;
+export type WhereInputPerModel<TModelName extends string, TPrismaClient> = {
+  [K in TModelName]: WhereInput<K, TPrismaClient>;
 };


### PR DESCRIPTION
### Context
Since version 6.6.0, Prisma recommends explicitly setting the output option when generating the Prisma Client and emits a warning if it is missing. Starting with version 7, this option will become mandatory, and the generated client files will no longer be placed in node_modules by default.

> In Prisma ORM 7, Prisma Client will no longer be generated in node_modules by default and will require an output path to be defined. [Prisma documentation](https://www.prisma.io/docs/orm/prisma-client/setup-and-configuration/generating-prisma-client)

However, the @casl/prisma package currently relies on the node_modules path to access the generated types, which will cause compatibility issues when upgrading to Prisma 7.

### Proposed Solution
This PR updates the package to allow for a smooth migration to Prisma 7 without introducing any breaking changes for current versions.

### Usage

**With Prisma < 7.0.0 and default generation in node_modules**

No changes are required.
It is not necessary to explicitly provide types to PrismaQuery, as it extends from PrismaClient and Prisma.ModelName found in node_modules.

**With Prisma ≥ 7.0.0 and client generated in a custom directory (e.g., src/generated)**

You now need to explicitly specify both the modelName and the PrismaClient type when using PrismaQuery.

```
import type {
  Company,
  Plan,
  Prisma,
  PrismaClient,
  User,
} from "@/generated/prisma";
import type { PureAbility } from "@casl/ability";
import type { PrismaQuery, Subjects } from "@casl/prisma";

import type { AbilityAction } from "@/modules/abilities/ability-action.enum";

export type AppAbility = PureAbility<
  [
    AbilityAction,
    | "all"
    | Subjects<{
        Company: Company;
        Plan: Plan;
        User: User;
      }>
  ],
  PrismaQuery<Prisma.ModelName, PrismaClient>
>;
```