### PR TITLE
fix(dx): add Windows compatibility for spawn commands

### DIFF
--- a/packages/dx/lib/spawn.js
+++ b/packages/dx/lib/spawn.js
@@ -1,9 +1,14 @@
 const child = require('child_process');
 
 function spawn(cli, args, options = {}) {
-  return child.spawn(cli, args, {
+  // Handle Windows compatibility
+  const isWindows = process.platform === 'win32';
+  const command = isWindows && !cli.endsWith('.cmd') && !cli.endsWith('.exe') ? cli + '.cmd' : cli;
+  
+  return child.spawn(command, args, {
     cwd: options.cwd || process.cwd(),
     stdio: 'inherit',
+    shell: isWindows, // Windows requires shell to execute commands properly
     env: {
       ...process.env,
       ...options.env,


### PR DESCRIPTION
- Add platform detection to determine if running on Windows
- Automatically append .cmd extension for Windows executables
- Enable shell option for Windows to properly handle commands
- Fixes pnpm install issues on Windows systems