### PR TITLE
Fix return type on `actionsFor`

### DIFF
--- a/packages/casl-ability/src/RuleIndex.ts
+++ b/packages/casl-ability/src/RuleIndex.ts
@@ -222,6 +222,7 @@ export class RuleIndex<A extends Abilities, Conditions> {
     return rules.filter(rule => rule.matchesField(field));
   }
 
+  actionsFor(subjectType: ExtractSubjectType<Normalize<A>[1]>): Normalize<A>[0][];
   actionsFor(subjectType: ExtractSubjectType<Normalize<A>[1]>): string[] {
     if (!isSubjectType(subjectType)) {
       throw new Error('"actionsFor" accepts only subject types (i.e., string or class) as a parameter');


### PR DESCRIPTION
Fixes the return type on `RuleIndex#actionsFor` to correctly return the actions type rather than always a `string[]`.

With this change, the results of `actionsFor` can be directly passed to the rules of a new ability(builder), i.e.: `abilityBuilder.can(otherAbility.actionsFor(SubjectA), SubjectB)`

Has no effect on runtime.