### PR TITLE
feat: export the Rule and RuleOptions types

### DIFF
--- a/packages/casl-ability/src/index.ts
+++ b/packages/casl-ability/src/index.ts
@@ -3,7 +3,7 @@ export * from './PureAbility';
 export * from './AbilityBuilder';
 export * from './ForbiddenError';
 export * from './RawRule';
-export * from './Rule';
+export type { Rule, RuleOptions } from './Rule';
 export * from './hkt';
 export * from './matchers/conditions';
 export * from './matchers/field';


### PR DESCRIPTION
Currently, we deep import `Rule` but with the new `"moduleResolution": "bundler"` this does not work as it is not exported from the `package.json`, this will allow users to correctly import the `Rule` and `RuleOptions` types.