### PR TITLE
feat(casl-typeorm): add TypeORM integration

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,6 +12,7 @@ on:
       - packages/casl-angular/README.md
       - packages/casl-aurelia/README.md
       - packages/casl-prisma/README.md
+      - packages/casl-typeorm/README.md
 
 jobs:
   build:

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -5,5 +5,6 @@
   "packages/casl-mongoose": "8.0.5",
   "packages/casl-prisma": "1.6.1",
   "packages/casl-react": "5.0.1",
-  "packages/casl-vue": "2.2.6"
+  "packages/casl-vue": "2.2.6",
+  "packages/casl-typeorm": "1.0.0"
 }

--- a/docs-src/src/config/menu.yml
+++ b/docs-src/src/config/menu.yml
@@ -16,6 +16,8 @@ items:
     - heading: packages
     - name: pkg-prisma
       page: package/casl-prisma
+    - name: pkg-typeorm
+      page: package/casl-typeorm
     - name: pkg-mongoose
       page: package/casl-mongoose
     - name: pkg-angular

--- a/docs-src/src/content/app/en.yml
+++ b/docs-src/src/content/app/en.yml
@@ -24,6 +24,7 @@ menu:
   ecosystem: Ecosystem
   packages: Official packages
   pkg-prisma: CASL Prisma
+  pkg-typeorm: CASL TypeORM
   pkg-mongoose: CASL Mongoose
   pkg-angular: CASL Angular
   pkg-react: CASL React

--- a/docs-src/src/content/pages/package/casl-typeorm/en.md
+++ b/docs-src/src/content/pages/package/casl-typeorm/en.md
@@ -1,0 +1,12 @@
+---
+title: CASL TypeORM
+categories: [package]
+order: 107
+meta:
+  keywords: typeorm authorization, permission management, casl, typeorm
+  description: >
+    TypeORM authorization using CASL permission management library.
+    Test permissions in runtime and query accessible records using TypeORM FindOptionsWhere conditions
+---
+
+@include: packages/casl-typeorm/README.md

--- a/packages/casl-typeorm/CHANGELOG.md
+++ b/packages/casl-typeorm/CHANGELOG.md
@@ -1,0 +1,1 @@
+# Change Log

--- a/packages/casl-typeorm/README.md
+++ b/packages/casl-typeorm/README.md
@@ -1,0 +1,211 @@
+# CASL TypeORM
+
+[![@casl/typeorm NPM version](https://badge.fury.io/js/%40casl%2Ftypeorm.svg)](https://badge.fury.io/js/%40casl%2Ftypeorm)
+[![](https://img.shields.io/npm/dm/%40casl%2Ftypeorm.svg)](https://www.npmjs.com/package/%40casl%2Ftypeorm)
+[![Support](https://img.shields.io/badge/Support-github%20discussions-green?style=flat&link=https://github.com/stalniy/casl/discussions)](https://github.com/stalniy/casl/discussions)
+
+This package allows to define [CASL] permissions on [TypeORM] entities using a conditions syntax inspired by TypeORM's `FindOptionsWhere`. And that brings a lot of power in terms of permission management in SQL world:
+
+1. We can use a familiar query language to define permissions, no need to learn MongoDB query language anymore.
+2. Additionally, we can ask our SQL database questions like: "Which records can be read?" or "Which records can be updated?".
+
+## Installation
+
+```sh
+npm install @casl/typeorm @casl/ability
+# or
+yarn add @casl/typeorm @casl/ability
+# or
+pnpm add @casl/typeorm @casl/ability
+```
+
+## Usage
+
+This package provides a custom `createTypeormAbility` factory function that is configured to check permissions using a conditions language mapped to TypeORM operators:
+
+```ts
+import { PureAbility, AbilityBuilder, subject } from '@casl/ability';
+import { createTypeormAbility, TypeormQuery, Subjects } from '@casl/typeorm';
+
+interface User {
+  id: number;
+  firstName: string;
+  age: number;
+}
+
+interface Post {
+  id: number;
+  title: string;
+  authorId: number;
+  status: string;
+}
+
+type AppAbility = PureAbility<[string, Subjects<{
+  User: User,
+  Post: Post
+}>], TypeormQuery>;
+const { can, cannot, build } = new AbilityBuilder<AppAbility>(createTypeormAbility);
+
+can('read', 'Post', { authorId: 1 });
+cannot('read', 'Post', { status: 'draft' });
+
+const ability = build();
+ability.can('read', 'Post');
+ability.can('read', subject('Post', { title: '...', authorId: 1, status: 'published' } as Post));
+```
+
+> See [CASL guide](https://casl.js.org/v6/en/guide/intro) to learn how to define abilities. Everything is the same except of conditions language.
+
+### Supported operators
+
+Conditions are plain JSON objects where field values can use these operators:
+
+| Operator | Description | Example |
+|---|---|---|
+| *(default)* | Equality | `{ id: 1 }` |
+| `equals` | Explicit equality | `{ id: { equals: 1 } }` |
+| `not` | Not equal / negated sub-query | `{ status: { not: 'draft' } }` |
+| `in` | Value in array | `{ id: { in: [1, 2, 3] } }` |
+| `notIn` | Value not in array | `{ id: { notIn: [1, 2] } }` |
+| `lt` | Less than | `{ age: { lt: 18 } }` |
+| `lte` | Less than or equal | `{ age: { lte: 65 } }` |
+| `gt` | Greater than | `{ age: { gt: 18 } }` |
+| `gte` | Greater than or equal | `{ age: { gte: 21 } }` |
+| `like` | SQL LIKE pattern | `{ name: { like: '%john%' } }` |
+| `ilike` | Case-insensitive LIKE | `{ name: { ilike: '%john%' } }` |
+| `between` | Between two values | `{ age: { between: [18, 65] } }` |
+| `isNull` | Is null check | `{ deletedAt: { isNull: true } }` |
+| `arrayContains` | Array contains all | `{ tags: { arrayContains: ['a'] } }` |
+| `arrayContainedBy` | Array contained by | `{ tags: { arrayContainedBy: ['a', 'b'] } }` |
+| `arrayOverlap` | Arrays share elements | `{ tags: { arrayOverlap: ['a', 'b'] } }` |
+
+Compound operators `AND`, `OR`, and `NOT` are also available at the top level:
+
+```ts
+can('read', 'Post', {
+  OR: [
+    { authorId: 1 },
+    { status: 'published' }
+  ]
+});
+```
+
+### Note on subject helper
+
+Because TypeORM query results are plain objects without type information, we need to use `subject` helper to provide that type manually, so CASL can understand what rules to apply to passed in object.
+
+> To get more details about object type detection, please read [CASL Subject type detection](https://casl.js.org/v6/en/guide/subject-type-detection)
+
+### Note on conditions runtime interpreter
+
+`@casl/typeorm` uses [ucast](https://github.com/stalniy/ucast) to interpret conditions in JavaScript runtime. However, there are few caveats:
+- `like` and `ilike` are interpreted using regex conversion (`%` → `.*`, `_` → `.`) which covers common patterns but not SQL-specific escaping
+- equality of JSON columns is not implemented
+- equality of array/list columns is not implemented (use `arrayContains`, `arrayContainedBy`, or `arrayOverlap` instead)
+
+Interpreter throws a `ParsingQueryError` in cases it receives invalid parameters for query operators or if some operation is not supported.
+
+## Finding Accessible Records
+
+One nice feature of [TypeORM] and [CASL] integration is that we can get all records from the database our user has access to. To do this, just use `accessibleBy` helper function:
+
+```ts
+import { accessibleBy } from '@casl/typeorm';
+
+// ability is created in the example above
+const accessiblePosts = await postRepository.find({
+  where: accessibleBy(ability).Post
+});
+```
+
+That function accepts `Ability` instance and `action` (defaults to `read`), returns an object with keys that corresponds to entity names and values being `FindOptionsWhere` compatible objects aggregated from permission rules.
+
+**Important**: in case user doesn't have ability to access any posts, `accessibleBy` throws `ForbiddenError`, so be ready to catch it!
+
+To combine this with business logic conditions, use an array (TypeORM's OR syntax) or spread into the same object (AND):
+
+```ts
+const accessiblePosts = await postRepository.find({
+  where: {
+    ...accessibleBy(ability).Post,
+    /* additional business conditions */
+  }
+});
+```
+
+For more complex combinations, you can use TypeORM's `And()` or build QueryBuilder queries:
+
+```ts
+import { And } from 'typeorm';
+
+// Using QueryBuilder
+const posts = await postRepository
+  .createQueryBuilder('post')
+  .where(accessibleBy(ability).Post)
+  .andWhere('post.createdAt > :date', { date: someDate })
+  .getMany();
+```
+
+### How accessibleBy converts rules
+
+- **Non-inverted rules** (`can`) are combined with OR logic (TypeORM's `where: [...]` array)
+- **Inverted rules** (`cannot`) have each field wrapped with TypeORM's `Not()` operator and merged into every OR branch
+- Operator values (e.g. `{ gt: 18 }`) are converted to the corresponding TypeORM `FindOperator` (e.g. `MoreThan(18)`)
+
+## TypeScript support
+
+The package is written in TypeScript what provides comprehensive IDE hints and compile time validation.
+
+Additionally, there are several helpers that make it easy to work with TypeORM and CASL:
+
+### TypeormQuery
+
+A type alias for the conditions format used by `@casl/typeorm`:
+
+```ts
+import { TypeormQuery } from '@casl/typeorm';
+```
+
+### Model
+
+Gives a name to an entity type. That name is stored using `ForcedSubject<TName>` helper from `@casl/ability`. To use a separate column or another strategy to name entities, don't use this helper because it only works in combination with `subject` helper.
+
+### Subjects
+
+Creates a union of all possible subjects out of passed in object:
+
+```ts
+import { Subjects } from '@casl/typeorm';
+
+type AppSubjects = Subjects<{
+  User: User,
+  Post: Post
+}>; // 'User' | Model<User, 'User'> | 'Post' | Model<Post, 'Post'>
+```
+
+To support rule definition for `all`, just add it explicitly:
+
+```ts
+type AppSubjects = 'all' | Subjects<{
+  User: User,
+  Post: Post
+}>;
+
+type AppAbility = PureAbility<[string, AppSubjects], TypeormQuery>;
+```
+
+## Want to help?
+
+Want to file a bug, contribute some code, or improve documentation? Excellent! Read up on guidelines for [contributing].
+
+If you'd like to help us sustain our community and project, consider [to become a financial contributor on Open Collective](https://opencollective.com/casljs/contribute)
+
+> See [Support CASL](https://casl.js.org/v6/en/support-casljs) for details
+
+## License
+
+[MIT License](http://www.opensource.org/licenses/MIT)
+
+[contributing]: https://github.com/stalniy/casl/blob/master/CONTRIBUTING.md
+[TypeORM]: https://typeorm.io/
+[CASL]: https://github.com/stalniy/casl

--- a/packages/casl-typeorm/package.json
+++ b/packages/casl-typeorm/package.json
@@ -1,0 +1,61 @@
+{
+  "name": "@casl/typeorm",
+  "version": "1.0.0",
+  "description": "Allows to define and evaluate CASL permissions using TypeORM FindOptionsWhere conditions, and query accessible records",
+  "main": "dist/es6c/index.js",
+  "es2015": "dist/es6m/index.mjs",
+  "typings": "dist/types/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/types/index.d.ts",
+      "import": "./dist/es6m/index.mjs",
+      "require": "./dist/es6c/index.js"
+    }
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/stalniy/casl.git",
+    "directory": "packages/casl-typeorm"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "homepage": "https://casl.js.org",
+  "scripts": {
+    "build.prepare": "rm -rf dist/* && npm run build.types",
+    "build": "npm run build.prepare && BUILD_TYPES=es6m,es6c dx rollup -e @casl/ability/extra,@casl/ability,typeorm,@ucast/core,@ucast/js",
+    "build.types": "dx tsc",
+    "lint": "dx eslint src/ spec/",
+    "test": "dx jest",
+    "release.prepare": "npm run lint && npm test && NODE_ENV=production npm run build",
+    "release": "npm run release.prepare && pnpm publish"
+  },
+  "keywords": [
+    "casl",
+    "typeorm",
+    "sql",
+    "authorization",
+    "acl",
+    "permissions"
+  ],
+  "author": "Sergii Stotskyi <sergiy.stotskiy@gmail.com>",
+  "license": "MIT",
+  "peerDependencies": {
+    "@casl/ability": "^5.3.0 || ^6.0.0",
+    "typeorm": "^0.3.0"
+  },
+  "devDependencies": {
+    "@casl/ability": "^6.0.0",
+    "@casl/dx": "workspace:^1.0.0",
+    "@types/jest": "^30.0.0",
+    "@types/node": "^24.0.0",
+    "typeorm": "^0.3.0"
+  },
+  "files": [
+    "dist"
+  ],
+  "dependencies": {
+    "@ucast/core": "^1.10.0",
+    "@ucast/js": "^3.0.1"
+  }
+}

--- a/packages/casl-typeorm/spec/AppAbility.ts
+++ b/packages/casl-typeorm/spec/AppAbility.ts
@@ -1,0 +1,25 @@
+import { PureAbility } from '@casl/ability'
+import { Subjects, TypeormQuery } from '../src'
+
+export interface User {
+  id: number
+  firstName: string
+  lastName: string
+  age: number
+  posts: Post[]
+}
+
+export interface Post {
+  id: number
+  title: string
+  authorId: number
+  status: string
+  active: boolean
+  tags: string[]
+  author: User
+}
+
+export type AppAbility = PureAbility<['create' | 'read' | 'update' | 'delete', 'all' | Subjects<{
+  User: User,
+  Post: Post
+}>], TypeormQuery>

--- a/packages/casl-typeorm/spec/TypeormAbility.spec.ts
+++ b/packages/casl-typeorm/spec/TypeormAbility.spec.ts
@@ -1,0 +1,103 @@
+import { AbilityBuilder, PureAbility, subject } from '@casl/ability'
+import { createTypeormAbility } from '../src'
+import { AppAbility, Post, User } from './AppAbility'
+
+describe('TypeormAbility', () => {
+  it('uses typeormQuery to evaluate conditions', () => {
+    const { can, build } = new AbilityBuilder<AppAbility>(createTypeormAbility)
+    can('read', 'Post', {
+      authorId: { notIn: [1, 2] }
+    })
+    can('read', 'User', {
+      firstName: { ilike: 'john%' }
+    })
+    const ability = build()
+
+    expect(ability.can('read', 'all')).toBe(false)
+    expect(ability.can('read', subject('Post', { authorId: 1 } as Post))).toBe(false)
+    expect(ability.can('read', subject('Post', { authorId: 2 } as Post))).toBe(false)
+    expect(ability.can('read', subject('Post', { authorId: 3 } as Post))).toBe(true)
+    expect(ability.can('read', subject('User', { firstName: 'John' } as User))).toBe(true)
+    expect(ability.can('read', subject('User', { firstName: 'john doe' } as User))).toBe(true)
+    expect(ability.can('read', subject('User', { firstName: 'Tom' } as User))).toBe(false)
+  })
+
+  it('evaluates "between" conditions', () => {
+    const { can, build } = new AbilityBuilder<AppAbility>(createTypeormAbility)
+    can('read', 'User', {
+      age: { between: [18, 65] }
+    })
+    const ability = build()
+
+    expect(ability.can('read', subject('User', { age: 25 } as User))).toBe(true)
+    expect(ability.can('read', subject('User', { age: 10 } as User))).toBe(false)
+    expect(ability.can('read', subject('User', { age: 70 } as User))).toBe(false)
+  })
+
+  it('evaluates "like" conditions', () => {
+    const { can, build } = new AbilityBuilder<AppAbility>(createTypeormAbility)
+    can('read', 'Post', {
+      title: { like: '%tutorial%' }
+    })
+    const ability = build()
+
+    expect(ability.can('read', subject('Post', { title: 'A tutorial on CASL' } as Post))).toBe(true)
+    expect(ability.can('read', subject('Post', { title: 'Random post' } as Post))).toBe(false)
+  })
+
+  it('evaluates "isNull" conditions', () => {
+    const { can, build } = new AbilityBuilder<AppAbility>(createTypeormAbility)
+    can('read', 'Post', {
+      status: { isNull: true }
+    })
+    const ability = build()
+
+    expect(ability.can('read', subject('Post', { status: null } as unknown as Post))).toBe(true)
+    expect(ability.can('read', subject('Post', { status: 'published' } as Post))).toBe(false)
+  })
+
+  it('evaluates array conditions', () => {
+    const { can, build } = new AbilityBuilder<AppAbility>(createTypeormAbility)
+    can('read', 'Post', {
+      tags: { arrayContains: ['typescript'] }
+    })
+    const ability = build()
+
+    expect(ability.can('read', subject('Post', { tags: ['typescript', 'casl'] } as Post))).toBe(true)
+    expect(ability.can('read', subject('Post', { tags: ['javascript'] } as Post))).toBe(false)
+  })
+
+  describe('types', () => {
+    it('ensures that only specified models can be used as subjects', () => {
+      expect(createTypeormAbility<AppAbility>([
+        {
+          action: 'read',
+          subject: 'Post'
+        },
+        {
+          action: 'update',
+          subject: 'User',
+          conditions: {
+            age: 11
+          }
+        },
+        {
+          action: 'read',
+          subject: 'all'
+        }
+      ])).toBeInstanceOf(PureAbility)
+    })
+
+    it('provides type validation in `AbilityBuilder`', () => {
+      const { can } = new AbilityBuilder<AppAbility>(createTypeormAbility)
+
+      can('read', 'Post', {
+        id: 1,
+        authorId: 1,
+      })
+      // @ts-expect-error unknown subject type
+      can('update', 'unknown')
+      can('delete', 'all')
+    })
+  })
+})

--- a/packages/casl-typeorm/spec/accessibleBy.spec.ts
+++ b/packages/casl-typeorm/spec/accessibleBy.spec.ts
@@ -1,0 +1,115 @@
+import { ForbiddenError } from '@casl/ability'
+import { Not } from 'typeorm'
+import { accessibleBy, createTypeormAbility } from '../src'
+import { AppAbility } from './AppAbility'
+
+describe('accessibleBy', () => {
+  const ability = createTypeormAbility<AppAbility>([
+    {
+      action: 'read',
+      subject: 'Post',
+      conditions: {
+        id: 1,
+      }
+    },
+    {
+      inverted: true,
+      action: 'read',
+      subject: 'Post',
+      conditions: {
+        status: 'draft'
+      }
+    }
+  ])
+
+  it('throws `ForbiddenError` if ability does not allow to execute action', () => {
+    expect(() => accessibleBy(ability, 'update').Post).toThrow(ForbiddenError as unknown as Error)
+  })
+
+  it('converts non-inverted rules to TypeORM FindOptionsWhere', () => {
+    const where = accessibleBy(ability).Post
+
+    expect(where).toEqual(expect.objectContaining({
+      id: 1
+    }))
+  })
+
+  it('wraps inverted rule field values with TypeORM Not()', () => {
+    const where = accessibleBy(ability).Post as Record<string, any>
+
+    expect(where.status).toEqual(Not('draft'))
+  })
+
+  it('returns single object when there is one OR and one AND condition', () => {
+    const where = accessibleBy(ability).Post
+
+    expect(where).toEqual({
+      id: 1,
+      status: Not('draft'),
+    })
+  })
+
+  it('returns array when there are multiple OR conditions', () => {
+    const multiAbility = createTypeormAbility<AppAbility>([
+      {
+        action: 'read',
+        subject: 'Post',
+        conditions: { id: 1 }
+      },
+      {
+        action: 'read',
+        subject: 'Post',
+        conditions: { status: 'published' }
+      }
+    ])
+
+    const where = accessibleBy(multiAbility).Post
+
+    expect(where).toEqual(expect.arrayContaining([
+      { id: 1 },
+      { status: 'published' }
+    ]))
+  })
+
+  it('distributes AND conditions across OR conditions', () => {
+    const multiAbility = createTypeormAbility<AppAbility>([
+      {
+        action: 'read',
+        subject: 'Post',
+        conditions: { id: 1 }
+      },
+      {
+        action: 'read',
+        subject: 'Post',
+        conditions: { authorId: 2 }
+      },
+      {
+        inverted: true,
+        action: 'read',
+        subject: 'Post',
+        conditions: { status: 'draft' }
+      }
+    ])
+
+    const where = accessibleBy(multiAbility).Post as Record<string, any>[]
+
+    expect(where).toHaveLength(2)
+    expect(where).toEqual(expect.arrayContaining([
+      expect.objectContaining({ id: 1, status: Not('draft') }),
+      expect.objectContaining({ authorId: 2, status: Not('draft') })
+    ]))
+  })
+
+  it('handles ability with no conditions (unconditional allow)', () => {
+    const unconditionalAbility = createTypeormAbility<AppAbility>([
+      {
+        action: 'read',
+        subject: 'Post'
+      }
+    ])
+
+    const where = accessibleBy(unconditionalAbility).Post
+
+    expect(where).toEqual({})
+  })
+})

--- a/packages/casl-typeorm/spec/typeormQuery.spec.ts
+++ b/packages/casl-typeorm/spec/typeormQuery.spec.ts
@@ -1,0 +1,431 @@
+import { typeormQuery } from '../src'
+
+describe('TypeormQuery evaluation', () => {
+  it('uses "equals" as default operator', () => {
+    const test = typeormQuery({ id: 1 })
+
+    expect(test({ id: 1 })).toBe(true)
+    expect(test({ id: 2 })).toBe(false)
+  })
+
+  describe('equals', () => {
+    it('throws when comparing with object or array', () => {
+      expect(() => typeormQuery({
+        items: {}
+      })).toThrow(/does not support comparison of arrays and objects/)
+      expect(() => typeormQuery({
+        items: Object.create(null)
+      })).toThrow(/does not support comparison of arrays and objects/)
+      expect(() => typeormQuery({
+        items: []
+      })).toThrow(/does not support comparison of arrays and objects/)
+    })
+
+    it('can compare `Date`s', () => {
+      const now = new Date()
+      const test = typeormQuery({ createdAt: now })
+
+      expect(test({ createdAt: new Date(now.toISOString()) })).toBe(true)
+      expect(test({ createdAt: new Date(1980) })).toBe(false)
+    })
+
+    it('can be specified using "equals" operator', () => {
+      const test = typeormQuery({
+        createdAt: { equals: 'test' }
+      })
+      expect(test({ createdAt: 'test' })).toBe(true)
+      expect(test({ createdAt: 'test2' })).toBe(false)
+    })
+  })
+
+  describe('not', () => {
+    it('throws when comparing with object without nested operators or array', () => {
+      expect(() => typeormQuery({
+        items: { not: {} }
+      })).toThrow(/does not support comparison of arrays and objects/)
+      expect(() => typeormQuery({
+        items: { not: Object.create(null) }
+      })).toThrow(/does not support comparison of arrays and objects/)
+      expect(() => typeormQuery({
+        items: { not: [] }
+      })).toThrow(/does not support comparison of arrays and objects/)
+    })
+
+    it('checks that object value does not equal provided primitive', () => {
+      const test = typeormQuery({ age: { not: 10 } })
+
+      expect(test({ age: 10 })).toBe(false)
+      expect(test({ age: 11 })).toBe(true)
+    })
+
+    it('checks that value satisfies nested operators', () => {
+      const test = typeormQuery({
+        age: {
+          not: {
+            gt: 18,
+            lt: 65
+          }
+        }
+      })
+
+      expect(test({ age: 30 })).toBe(false)
+      expect(test({ age: 10 })).toBe(true)
+      expect(test({ age: 70 })).toBe(true)
+    })
+  })
+
+  describe('in', () => {
+    it('throws if passed value is not an array', () => {
+      expect(() => typeormQuery({
+        items: { in: {} }
+      })).toThrow(/expects to receive an array/)
+    })
+
+    it('checks that object value is in specified enum values', () => {
+      const test = typeormQuery({ id: { in: [1, 2] } })
+
+      expect(test({ id: 1 })).toBe(true)
+      expect(test({ id: 2 })).toBe(true)
+      expect(test({ id: 3 })).toBe(false)
+    })
+  })
+
+  describe('notIn', () => {
+    it('throws if passed value is not an array', () => {
+      expect(() => typeormQuery({
+        items: { notIn: {} }
+      })).toThrow(/expects to receive an array/)
+    })
+
+    it('checks that object value is NOT in specified enum values', () => {
+      const test = typeormQuery({ id: { notIn: [1, 2] } })
+
+      expect(test({ id: 1 })).toBe(false)
+      expect(test({ id: 2 })).toBe(false)
+      expect(test({ id: 3 })).toBe(true)
+    })
+  })
+
+  describe('lt, lte', () => {
+    it('throws if value is not comparable (string, number or Date)', () => {
+      expect(() => typeormQuery({
+        name: { lt: true }
+      })).toThrow(/expects to receive comparable value/)
+      expect(() => typeormQuery({
+        name: { lte: [] }
+      })).toThrow(/expects to receive comparable value/)
+      expect(() => typeormQuery({
+        name: { lte: NaN }
+      })).toThrow(/expects to receive comparable value/)
+      expect(() => typeormQuery({
+        name: { lt: Infinity }
+      })).toThrow(/expects to receive comparable value/)
+    })
+
+    it('checks that object value is less than specified one when using "lt"', () => {
+      const test = typeormQuery({ age: { lt: 10 } })
+      expect(test({ age: 9 })).toBe(true)
+      expect(test({ age: 10 })).toBe(false)
+    })
+
+    it('checks that object value is less or equal to specified one when using "lte"', () => {
+      const test = typeormQuery({ age: { lte: 10 } })
+      expect(test({ age: 9 })).toBe(true)
+      expect(test({ age: 10 })).toBe(true)
+    })
+  })
+
+  describe('gt, gte', () => {
+    it('throws if value is not comparable (string, number or Date)', () => {
+      expect(() => typeormQuery({
+        name: { gt: true }
+      })).toThrow(/expects to receive comparable value/)
+      expect(() => typeormQuery({
+        name: { gte: [] }
+      })).toThrow(/expects to receive comparable value/)
+      expect(() => typeormQuery({
+        name: { gte: NaN }
+      })).toThrow(/expects to receive comparable value/)
+      expect(() => typeormQuery({
+        name: { gt: Infinity }
+      })).toThrow(/expects to receive comparable value/)
+    })
+
+    it('checks that object value is greater than specified one when using "gt"', () => {
+      const test = typeormQuery({ age: { gt: 10 } })
+      expect(test({ age: 11 })).toBe(true)
+      expect(test({ age: 10 })).toBe(false)
+    })
+
+    it('checks that object value is greater or equal to specified one when using "gte"', () => {
+      const test = typeormQuery({ age: { gte: 10 } })
+      expect(test({ age: 11 })).toBe(true)
+      expect(test({ age: 10 })).toBe(true)
+    })
+  })
+
+  describe('like', () => {
+    it('throws if value is not a string', () => {
+      expect(() => typeormQuery({
+        name: { like: 1 }
+      })).toThrow(/expects to receive string/)
+      expect(() => typeormQuery({
+        name: { like: {} }
+      })).toThrow(/expects to receive string/)
+    })
+
+    it('checks that value matches LIKE pattern (% = wildcard)', () => {
+      const test = typeormQuery({ name: { like: '%john%' } })
+
+      expect(test({ name: 'john' })).toBe(true)
+      expect(test({ name: 'John' })).toBe(false)
+      expect(test({ name: 'mr john doe' })).toBe(true)
+      expect(test({ name: 'tom' })).toBe(false)
+    })
+
+    it('supports _ as single character wildcard', () => {
+      const test = typeormQuery({ code: { like: 'A_C' } })
+
+      expect(test({ code: 'ABC' })).toBe(true)
+      expect(test({ code: 'AXC' })).toBe(true)
+      expect(test({ code: 'ABBC' })).toBe(false)
+    })
+  })
+
+  describe('ilike', () => {
+    it('throws if value is not a string', () => {
+      expect(() => typeormQuery({
+        name: { ilike: 1 }
+      })).toThrow(/expects to receive string/)
+    })
+
+    it('checks case-insensitive LIKE pattern', () => {
+      const test = typeormQuery({ name: { ilike: '%john%' } })
+
+      expect(test({ name: 'john' })).toBe(true)
+      expect(test({ name: 'John' })).toBe(true)
+      expect(test({ name: 'JOHN DOE' })).toBe(true)
+      expect(test({ name: 'tom' })).toBe(false)
+    })
+  })
+
+  describe('between', () => {
+    it('throws if value is not an array of 2 elements', () => {
+      expect(() => typeormQuery({
+        age: { between: 5 }
+      })).toThrow(/expects to receive an array of 2 elements/)
+      expect(() => typeormQuery({
+        age: { between: [1] }
+      })).toThrow(/expects to receive an array of 2 elements/)
+      expect(() => typeormQuery({
+        age: { between: [1, 2, 3] }
+      })).toThrow(/expects to receive an array of 2 elements/)
+    })
+
+    it('checks that value is between min and max (inclusive)', () => {
+      const test = typeormQuery({ age: { between: [18, 65] } })
+
+      expect(test({ age: 18 })).toBe(true)
+      expect(test({ age: 30 })).toBe(true)
+      expect(test({ age: 65 })).toBe(true)
+      expect(test({ age: 17 })).toBe(false)
+      expect(test({ age: 66 })).toBe(false)
+    })
+  })
+
+  describe('isNull', () => {
+    it('throws if value is not a boolean', () => {
+      expect(() => typeormQuery({ name: { isNull: 1 } })).toThrow(/expects to receive a boolean/)
+      expect(() => typeormQuery({ name: { isNull: {} } })).toThrow(/expects to receive a boolean/)
+    })
+
+    it('checks that value is null when isNull is true', () => {
+      const test = typeormQuery({ name: { isNull: true } })
+
+      expect(test({ name: null })).toBe(true)
+      expect(test({ name: 'john' })).toBe(false)
+    })
+
+    it('checks that value is not null when isNull is false', () => {
+      const test = typeormQuery({ name: { isNull: false } })
+
+      expect(test({ name: null })).toBe(false)
+      expect(test({ name: 'john' })).toBe(true)
+    })
+  })
+
+  describe('arrayContains', () => {
+    it('throws if value is not an array', () => {
+      expect(() => typeormQuery({
+        tags: { arrayContains: 'test' }
+      })).toThrow(/expects to receive an array/)
+    })
+
+    it('checks that array contains all specified values', () => {
+      const test = typeormQuery({ tags: { arrayContains: ['a', 'b'] } })
+
+      expect(test({ tags: ['a', 'b', 'c'] })).toBe(true)
+      expect(test({ tags: ['a', 'b'] })).toBe(true)
+      expect(test({ tags: ['a'] })).toBe(false)
+      expect(test({ tags: ['c'] })).toBe(false)
+    })
+  })
+
+  describe('arrayContainedBy', () => {
+    it('throws if value is not an array', () => {
+      expect(() => typeormQuery({
+        tags: { arrayContainedBy: 'test' }
+      })).toThrow(/expects to receive an array/)
+    })
+
+    it('checks that array is contained by specified values', () => {
+      const test = typeormQuery({ tags: { arrayContainedBy: ['a', 'b', 'c'] } })
+
+      expect(test({ tags: ['a', 'b'] })).toBe(true)
+      expect(test({ tags: ['a'] })).toBe(true)
+      expect(test({ tags: ['a', 'b', 'c'] })).toBe(true)
+      expect(test({ tags: ['a', 'd'] })).toBe(false)
+    })
+  })
+
+  describe('arrayOverlap', () => {
+    it('throws if value is not an array', () => {
+      expect(() => typeormQuery({
+        tags: { arrayOverlap: 'test' }
+      })).toThrow(/expects to receive an array/)
+    })
+
+    it('checks that array has at least one common element', () => {
+      const test = typeormQuery({ tags: { arrayOverlap: ['a', 'b'] } })
+
+      expect(test({ tags: ['a', 'c'] })).toBe(true)
+      expect(test({ tags: ['b', 'c'] })).toBe(true)
+      expect(test({ tags: ['c', 'd'] })).toBe(false)
+    })
+  })
+
+  describe('AND', () => {
+    it('throws if value is not an object or array', () => {
+      expect(() => typeormQuery({
+        AND: 1
+      })).toThrow(/expects to receive an array or object/)
+      expect(() => typeormQuery({
+        AND: 'test'
+      })).toThrow(/expects to receive an array or object/)
+    })
+
+    it('combines criteria passed as an array using logical AND', () => {
+      const test = typeormQuery({
+        AND: [
+          { age: { gte: 18 } },
+          { active: true }
+        ]
+      })
+
+      expect(test({})).toBe(false)
+      expect(test({ active: true, age: 5 })).toBe(false)
+      expect(test({ active: false, age: 18 })).toBe(false)
+      expect(test({ active: true, age: 18 })).toBe(true)
+      expect(test({ active: true, age: 19 })).toBe(true)
+    })
+
+    it('combines criteria passed as an object using logical AND', () => {
+      const test = typeormQuery({
+        AND: {
+          age: { gte: 18 },
+          active: true
+        },
+      })
+
+      expect(test({})).toBe(false)
+      expect(test({ active: true, age: 5 })).toBe(false)
+      expect(test({ active: false, age: 18 })).toBe(false)
+      expect(test({ active: true, age: 18 })).toBe(true)
+      expect(test({ active: true, age: 19 })).toBe(true)
+    })
+  })
+
+  describe('OR', () => {
+    it('throws if value is not an object or array', () => {
+      expect(() => typeormQuery({
+        OR: 1
+      })).toThrow(/expects to receive an array or object/)
+      expect(() => typeormQuery({
+        OR: 'test'
+      })).toThrow(/expects to receive an array or object/)
+    })
+
+    it('combines criteria passed as an array using logical OR', () => {
+      const test = typeormQuery({
+        OR: [
+          { age: { gte: 18 } },
+          { active: true }
+        ]
+      })
+
+      expect(test({})).toBe(false)
+      expect(test({ active: true, age: 5 })).toBe(true)
+      expect(test({ active: false, age: 18 })).toBe(true)
+      expect(test({ active: true, age: 18 })).toBe(true)
+      expect(test({ active: true, age: 19 })).toBe(true)
+      expect(test({ active: false, age: 5 })).toBe(false)
+    })
+
+    it('combines criteria passed as an object using logical AND (mimics compound behavior)', () => {
+      const test = typeormQuery({
+        OR: {
+          age: { gte: 18 },
+          active: true
+        },
+      })
+
+      expect(test({})).toBe(false)
+      expect(test({ active: true, age: 5 })).toBe(false)
+      expect(test({ active: false, age: 18 })).toBe(false)
+      expect(test({ active: true, age: 18 })).toBe(true)
+      expect(test({ active: true, age: 19 })).toBe(true)
+    })
+  })
+
+  describe('NOT', () => {
+    it('throws if value is not an object or array', () => {
+      expect(() => typeormQuery({
+        NOT: 1
+      })).toThrow(/expects to receive an array or object/)
+      expect(() => typeormQuery({
+        NOT: 'test'
+      })).toThrow(/expects to receive an array or object/)
+    })
+
+    it('combines an array of criteria with logical AND NOTs', () => {
+      const test = typeormQuery({
+        NOT: [
+          { age: { gte: 18 } },
+          { active: true }
+        ]
+      })
+
+      expect(test({})).toBe(true)
+      expect(test({ active: true, age: 5 })).toBe(false)
+      expect(test({ active: false, age: 18 })).toBe(false)
+      expect(test({ active: false, age: 19 })).toBe(false)
+      expect(test({ active: true, age: 18 })).toBe(false)
+      expect(test({ active: true, age: 19 })).toBe(false)
+      expect(test({ active: false, age: 5 })).toBe(true)
+    })
+
+    it('inverts criteria passed as an object', () => {
+      const test = typeormQuery({
+        NOT: {
+          age: { gte: 18 },
+          active: true
+        },
+      })
+
+      expect(test({})).toBe(true)
+      expect(test({ active: true, age: 5 })).toBe(true)
+      expect(test({ active: false, age: 18 })).toBe(true)
+      expect(test({ active: true, age: 18 })).toBe(false)
+    })
+  })
+})

--- a/packages/casl-typeorm/src/accessibleBy.ts
+++ b/packages/casl-typeorm/src/accessibleBy.ts
@@ -1,0 +1,137 @@
+import { rulesToQuery } from '@casl/ability/extra';
+import { AnyAbility, ForbiddenError, PureAbility } from '@casl/ability';
+import {
+  Not,
+  In,
+  LessThan,
+  LessThanOrEqual,
+  MoreThan,
+  MoreThanOrEqual,
+  Like,
+  ILike,
+  Between,
+  IsNull,
+  ArrayContains,
+  ArrayContainedBy,
+  ArrayOverlap,
+  Equal,
+  And,
+} from 'typeorm';
+import type { FindOptionsWhere } from 'typeorm';
+
+const isPlainObject = (value: any): value is Record<string, any> => {
+  return value !== null && typeof value === 'object'
+    && (value.constructor === Object || !value.constructor);
+};
+
+function operatorToFindOperator(op: string, value: any): any {
+  switch (op) {
+    case 'equals': return Equal(value);
+    case 'not': {
+      if (isPlainObject(value)) {
+        const inner = toFindOptionsWhere(value);
+        const keys = Object.keys(inner);
+        if (keys.length === 1) {
+          return Not(inner[keys[0]]);
+        }
+        return Not(And(...keys.map(k => inner[k])));
+      }
+      return Not(value);
+    }
+    case 'in': return In(value);
+    case 'notIn': return Not(In(value));
+    case 'lt': return LessThan(value);
+    case 'lte': return LessThanOrEqual(value);
+    case 'gt': return MoreThan(value);
+    case 'gte': return MoreThanOrEqual(value);
+    case 'like': return Like(value);
+    case 'ilike': return ILike(value);
+    case 'between': return Between(value[0], value[1]);
+    case 'isNull': return value ? IsNull() : Not(IsNull());
+    case 'arrayContains': return ArrayContains(value);
+    case 'arrayContainedBy': return ArrayContainedBy(value);
+    case 'arrayOverlap': return ArrayOverlap(value);
+    default: return value;
+  }
+}
+
+function toFindOptionsWhere(conditions: Record<string, any>): Record<string, any> {
+  const where: Record<string, any> = {};
+
+  for (const [key, value] of Object.entries(conditions)) {
+    if (key === 'AND' || key === 'OR' || key === 'NOT') continue;
+
+    if (isPlainObject(value)) {
+      const ops = Object.keys(value);
+      const operators = ops.map(op => operatorToFindOperator(op, value[op]));
+      where[key] = operators.length === 1 ? operators[0] : And(...operators);
+    } else {
+      where[key] = value;
+    }
+  }
+
+  return where;
+}
+
+function convertToTypeormQuery(rule: AnyAbility['rules'][number]) {
+  return rule.inverted ? { NOT: rule.conditions } : rule.conditions;
+}
+
+type TypeormWhereInput = Record<string, Record<string, any> | FindOptionsWhere<any>[]>;
+
+const proxyHandlers: ProxyHandler<{ _ability: AnyAbility, _action: string }> = {
+  get(target, subjectType) {
+    const query = rulesToQuery(target._ability, target._action, subjectType, convertToTypeormQuery);
+
+    if (query === null) {
+      const error = ForbiddenError.from(target._ability)
+        .setMessage(`It's not allowed to run "${target._action}" on "${subjectType as string}"`);
+      error.action = target._action;
+      error.subjectType = error.subject = subjectType as string;
+      throw error;
+    }
+
+    const orConditions = (query.$or || []).map(toFindOptionsWhere);
+    const andConditions = (query.$and || []).map(c => {
+      const notBody = (c as any).NOT;
+      if (notBody) {
+        const inner = toFindOptionsWhere(notBody);
+        const result: Record<string, any> = {};
+        for (const [key, val] of Object.entries(inner)) {
+          result[key] = Not(val);
+        }
+        return result;
+      }
+      return toFindOptionsWhere(c);
+    });
+
+    const mergedAnd = andConditions.length > 0
+      ? Object.assign({}, ...andConditions)
+      : null;
+
+    if (orConditions.length === 0 && mergedAnd) {
+      return mergedAnd;
+    }
+
+    if (orConditions.length === 0) {
+      return {};
+    }
+
+    if (!mergedAnd) {
+      return orConditions.length === 1 ? orConditions[0] : orConditions;
+    }
+
+    const result = orConditions.map(or => ({ ...or, ...mergedAnd }));
+    return result.length === 1 ? result[0] : result;
+  }
+};
+
+export function accessibleBy<TAbility extends PureAbility<any, any>>(
+  ability: TAbility,
+  action: TAbility['rules'][number]['action'] = 'read'
+): TypeormWhereInput {
+  return new Proxy({
+    _ability: ability,
+    _action: action,
+  }, proxyHandlers) as unknown as TypeormWhereInput;
+}

--- a/packages/casl-typeorm/src/createAbilityFactory.ts
+++ b/packages/casl-typeorm/src/createAbilityFactory.ts
@@ -1,0 +1,35 @@
+import {
+  AbilityOptions,
+  AbilityOptionsOf,
+  AbilityTuple,
+  fieldPatternMatcher,
+  PureAbility,
+  RawRuleFrom,
+  RawRuleOf
+} from '@casl/ability';
+import { typeormQuery } from './typeorm/typeormQuery';
+
+export function createAbilityFactory<
+  TModelName extends string,
+  TTypeormQuery extends Record<string, any>
+>() {
+  function createAbility<
+    T extends PureAbility<any, TTypeormQuery>
+  >(rules?: RawRuleOf<T>[], options?: AbilityOptionsOf<T>): T;
+  function createAbility<
+    A extends AbilityTuple = [string, TModelName],
+    C extends TTypeormQuery = TTypeormQuery
+  >(
+    rules?: RawRuleFrom<A, C>[],
+    options?: AbilityOptions<A, C>
+  ): PureAbility<A, C>;
+  function createAbility(rules: any[] = [], options = {}): PureAbility<any, any> {
+    return new PureAbility(rules, {
+      ...options,
+      conditionsMatcher: typeormQuery,
+      fieldMatcher: fieldPatternMatcher,
+    });
+  }
+
+  return createAbility;
+}

--- a/packages/casl-typeorm/src/errors/ParsingQueryError.ts
+++ b/packages/casl-typeorm/src/errors/ParsingQueryError.ts
@@ -1,0 +1,8 @@
+export class ParsingQueryError extends Error {
+  static invalidArgument(operatorName: string, value: unknown, expectValueType: string) {
+    const valueType = `${typeof value}(${JSON.stringify(value, null, 2)})`;
+    return new this(
+      `"${operatorName}" expects to receive ${expectValueType} but instead got "${valueType}"`
+    );
+  }
+}

--- a/packages/casl-typeorm/src/index.ts
+++ b/packages/casl-typeorm/src/index.ts
@@ -1,0 +1,40 @@
+import {
+  AbilityOptions,
+  AbilityTuple,
+  fieldPatternMatcher,
+  PureAbility,
+  RawRuleFrom
+} from '@casl/ability';
+import { typeormQuery } from './typeorm/typeormQuery';
+
+export { typeormQuery } from './typeorm/typeormQuery';
+export type { Model, Subjects, ExtractModelName } from './typeorm/typeormQuery';
+export { accessibleBy } from './accessibleBy';
+export { createAbilityFactory } from './createAbilityFactory';
+export { ParsingQueryError } from './errors/ParsingQueryError';
+export type {
+  TypeormModel,
+  TypeormWhereInput,
+  TypeormQueryFactory,
+  BaseTypeormQuery,
+} from './types';
+
+export type TypeormQuery = Record<string, any>;
+
+export function createTypeormAbility<
+  T extends PureAbility<any, any>
+>(rules?: RawRuleFrom<any, any>[], options?: AbilityOptions<any, any>): T;
+export function createTypeormAbility<
+  A extends AbilityTuple = [string, string],
+  C extends TypeormQuery = TypeormQuery
+>(
+  rules?: RawRuleFrom<A, C>[],
+  options?: AbilityOptions<A, C>
+): PureAbility<A, C>;
+export function createTypeormAbility(rules: any[] = [], options = {}): PureAbility<any, any> {
+  return new PureAbility(rules, {
+    ...options,
+    conditionsMatcher: typeormQuery,
+    fieldMatcher: fieldPatternMatcher,
+  });
+}

--- a/packages/casl-typeorm/src/typeorm/TypeormQueryParser.ts
+++ b/packages/casl-typeorm/src/typeorm/TypeormQueryParser.ts
@@ -1,0 +1,182 @@
+import {
+  buildAnd,
+  Comparable,
+  CompoundCondition,
+  CompoundInstruction,
+  Condition,
+  FieldCondition,
+  FieldInstruction,
+  ObjectQueryFieldParsingContext,
+  ObjectQueryParser
+} from '@ucast/core';
+import { ParsingQueryError } from '../errors/ParsingQueryError';
+
+const isPlainObject = (value: any) => {
+  return value && (value.constructor === Object || !value.constructor);
+};
+
+const equals: FieldInstruction = {
+  type: 'field',
+  validate(instruction, value) {
+    if (Array.isArray(value) || isPlainObject(value)) {
+      throw new ParsingQueryError(`"${instruction.name}" does not support comparison of arrays and objects`);
+    }
+  }
+};
+
+const not: FieldInstruction<unknown, ObjectQueryFieldParsingContext> = {
+  type: 'field',
+  parse(instruction, value, { hasOperators, field, parse }) {
+    if (isPlainObject(value) && !hasOperators(value) || Array.isArray(value)) {
+      throw new ParsingQueryError(`"${instruction.name}" does not support comparison of arrays and objects`);
+    }
+
+    if (!isPlainObject(value)) {
+      return new FieldCondition('notEquals', field, value);
+    }
+
+    return new CompoundCondition('NOT', [parse(value, { field })]);
+  }
+};
+
+const within: FieldInstruction<unknown[]> = {
+  type: 'field',
+  validate(instruction, value) {
+    if (!Array.isArray(value)) {
+      throw ParsingQueryError.invalidArgument(instruction.name, value, 'an array');
+    }
+  }
+};
+
+const comparable: FieldInstruction<Comparable> = {
+  type: 'field',
+  validate(instruction, value) {
+    const type = typeof value;
+    const isComparable = type === 'string'
+      || type === 'number' && Number.isFinite(value)
+      || value instanceof Date;
+
+    if (!isComparable) {
+      throw ParsingQueryError.invalidArgument(instruction.name, value, 'comparable value');
+    }
+  }
+};
+
+const stringField: FieldInstruction<string> = {
+  type: 'field',
+  validate(instruction, value) {
+    if (typeof value !== 'string') {
+      throw ParsingQueryError.invalidArgument(instruction.name, value, 'string');
+    }
+  }
+};
+
+const between: FieldInstruction<[Comparable, Comparable]> = {
+  type: 'field',
+  validate(instruction, value) {
+    if (!Array.isArray(value) || value.length !== 2) {
+      throw ParsingQueryError.invalidArgument(instruction.name, value, 'an array of 2 elements [min, max]');
+    }
+  }
+};
+
+const booleanField: FieldInstruction<boolean> = {
+  type: 'field',
+  validate(instruction, value) {
+    if (typeof value !== 'boolean') {
+      throw ParsingQueryError.invalidArgument(instruction.name, value, 'a boolean');
+    }
+  }
+};
+
+const arrayField: FieldInstruction<unknown[]> = {
+  type: 'field',
+  validate(instruction, value) {
+    if (!Array.isArray(value)) {
+      throw ParsingQueryError.invalidArgument(instruction.name, value, 'an array');
+    }
+  }
+};
+
+const compound: CompoundInstruction = {
+  type: 'compound',
+  validate(instruction, value) {
+    if (!value || typeof value !== 'object') {
+      throw ParsingQueryError.invalidArgument(instruction.name, value, 'an array or object');
+    }
+  },
+  parse(instruction, arrayOrObject, { parse }) {
+    const value = Array.isArray(arrayOrObject) ? arrayOrObject : [arrayOrObject];
+    const conditions = value.map(v => parse(v));
+    return new CompoundCondition(instruction.name, conditions);
+  }
+};
+
+const inverted = (name: string, baseInstruction: FieldInstruction): FieldInstruction => {
+  const parse = baseInstruction.parse;
+
+  if (!parse) {
+    return {
+      ...baseInstruction,
+      parse(_, value, ctx) {
+        return new CompoundCondition('NOT', [new FieldCondition(name, ctx.field, value)]);
+      }
+    };
+  }
+
+  return {
+    ...baseInstruction,
+    parse(instruction, value, ctx) {
+      const condition = parse(instruction, value, ctx);
+      if (condition.operator !== instruction.name) {
+        throw new Error(`Cannot invert "${name}" operator parser because it returns a complex Condition`);
+      }
+      (condition as Mutable<Condition>).operator = name;
+      return new CompoundCondition('NOT', [condition]);
+    }
+  };
+};
+
+const instructions = {
+  equals,
+  not,
+  in: within,
+  notIn: inverted('in', within),
+  lt: comparable,
+  lte: comparable,
+  gt: comparable,
+  gte: comparable,
+  like: stringField,
+  ilike: stringField,
+  between,
+  isNull: booleanField,
+  arrayContains: arrayField,
+  arrayContainedBy: arrayField,
+  arrayOverlap: arrayField,
+  NOT: compound,
+  AND: compound,
+  OR: compound,
+};
+
+export interface ParseOptions {
+  field: string
+}
+
+type Query = Record<string, any>;
+export class TypeormQueryParser extends ObjectQueryParser<Query> {
+  constructor() {
+    super(instructions, {
+      defaultOperatorName: 'equals',
+    });
+  }
+
+  parse(query: Query, options?: ParseOptions): Condition {
+    if (options && options.field) {
+      return buildAnd(this.parseFieldOperators(options.field, query));
+    }
+
+    return super.parse(query);
+  }
+}
+
+type Mutable<T> = { -readonly [K in keyof T]: T[K] };

--- a/packages/casl-typeorm/src/typeorm/interpretTypeormQuery.ts
+++ b/packages/casl-typeorm/src/typeorm/interpretTypeormQuery.ts
@@ -1,0 +1,134 @@
+import { CompoundCondition, FieldCondition } from "@ucast/core";
+import {
+  JsInterpreter,
+  createJsInterpreter,
+  eq,
+  ne,
+  and,
+  or,
+  within,
+  lt,
+  lte,
+  gt,
+  gte,
+  compare,
+} from "@ucast/js";
+
+type StringInterpreter = JsInterpreter<
+  FieldCondition<string>,
+  Record<string, string>
+>;
+const like: StringInterpreter = (condition, object, { get }) => {
+  const value = get(object, condition.field);
+  const pattern = condition.value.replace(/%/g, ".*").replace(/_/g, ".");
+  return new RegExp(`^${pattern}$`).test(value);
+};
+
+const ilike: StringInterpreter = (condition, object, { get }) => {
+  const value = get(object, condition.field);
+  const pattern = condition.value.replace(/%/g, ".*").replace(/_/g, ".");
+  return new RegExp(`^${pattern}$`, "i").test(value);
+};
+
+type BetweenInterpreter = JsInterpreter<
+  FieldCondition<[unknown, unknown]>,
+  Record<string, unknown>
+>;
+const between: BetweenInterpreter = (
+  condition,
+  object,
+  { get, compare: cmp },
+) => {
+  const value = get(object, condition.field);
+  const [min, max] = condition.value;
+  return cmp(value, min) >= 0 && cmp(value, max) <= 0;
+};
+
+type BooleanFieldInterpreter = JsInterpreter<
+  FieldCondition<boolean>,
+  Record<string, unknown>
+>;
+const isNull: BooleanFieldInterpreter = (condition, object, { get }) => {
+  const value = get(object, condition.field);
+  return condition.value ? value === null : value !== null;
+};
+
+type ArrayInterpreter<
+  TConditionValue,
+  TValue extends Record<string, unknown[]> = Record<string, unknown[]>,
+> = JsInterpreter<FieldCondition<TConditionValue>, TValue>;
+const arrayContains: ArrayInterpreter<unknown[]> = (
+  condition,
+  object,
+  { get },
+) => {
+  const value = get(object, condition.field);
+  return (
+    Array.isArray(value) && condition.value.every((v) => value.includes(v))
+  );
+};
+
+const arrayContainedBy: ArrayInterpreter<unknown[]> = (
+  condition,
+  object,
+  { get },
+) => {
+  const value = get(object, condition.field);
+  return (
+    Array.isArray(value) && value.every((v) => condition.value.includes(v))
+  );
+};
+
+const arrayOverlap: ArrayInterpreter<unknown[]> = (
+  condition,
+  object,
+  { get },
+) => {
+  const value = get(object, condition.field);
+  return Array.isArray(value) && condition.value.some((v) => value.includes(v));
+};
+
+const not: JsInterpreter<CompoundCondition> = (
+  condition,
+  object,
+  { interpret },
+) => {
+  return condition.value.every(
+    (subCondition) => !interpret(subCondition, object),
+  );
+};
+
+function toComparable(value: unknown) {
+  return value && typeof value === "object" ? value.valueOf() : value;
+}
+
+const compareValues: typeof compare = (a, b) =>
+  compare(toComparable(a), toComparable(b));
+
+export const interpretTypeormQuery = createJsInterpreter(
+  {
+    equals: eq,
+    notEquals: ne,
+    in: within,
+    lt,
+    lte,
+    gt,
+    gte,
+    like,
+    ilike,
+    between,
+    isNull,
+    arrayContains,
+    arrayContainedBy,
+    arrayOverlap,
+    and,
+    or,
+    AND: and,
+    OR: or,
+    NOT: not,
+  },
+  {
+    get: (object, field) => object[field],
+    compare: compareValues,
+  },
+);

--- a/packages/casl-typeorm/src/typeorm/typeormQuery.ts
+++ b/packages/casl-typeorm/src/typeorm/typeormQuery.ts
@@ -1,0 +1,26 @@
+import { AnyInterpreter, createTranslatorFactory } from '@ucast/core';
+import { ForcedSubject } from '@casl/ability';
+import { TypeormQueryParser } from './TypeormQueryParser';
+import { interpretTypeormQuery } from './interpretTypeormQuery';
+
+const parser = new TypeormQueryParser();
+export const typeormQuery = createTranslatorFactory(
+  parser.parse,
+  interpretTypeormQuery as AnyInterpreter
+);
+
+export type Model<T, TName extends string> = T & ForcedSubject<TName>;
+export type Subjects<T extends Partial<Record<string, Record<string, unknown>>>> =
+  | keyof T
+  | { [K in keyof T]: Model<T[K], K & string> }[keyof T];
+
+export type ExtractModelName<
+  TObject,
+  TModelName extends PropertyKey
+> = TObject extends { kind: TModelName }
+  ? TObject['kind']
+  : TObject extends ForcedSubject<TModelName>
+    ? TObject['__caslSubjectType__']
+    : TObject extends { __typename: TModelName }
+      ? TObject['__typename']
+      : TModelName;

--- a/packages/casl-typeorm/src/types.ts
+++ b/packages/casl-typeorm/src/types.ts
@@ -1,0 +1,34 @@
+import type { hkt } from "@casl/ability";
+import type { ExtractModelName, Model } from "./typeorm/typeormQuery";
+
+export type TypeormModel = Model<Record<string, any>, string>;
+
+export type TypeormWhereInput<
+  TEntities extends Record<string, Record<string, any>>,
+> = {
+  [K in keyof TEntities]: Record<string, any>;
+};
+
+interface TypeormQueryTypeFactory<
+  TEntities extends Record<string, Record<string, any>>,
+>
+  extends hkt.GenericFactory {
+  produce: TypeormWhereInput<TEntities>[ExtractModelName<
+    this[0],
+    Extract<keyof TEntities, string>
+  >];
+}
+
+export declare const ɵtypeormTypes: unique symbol;
+export type TypeormQueryFactory<
+  TEntities extends Record<string, Record<string, any>>,
+  T = TypeormModel,
+> = TypeormWhereInput<TEntities>[ExtractModelName<
+  T,
+  Extract<keyof TEntities, string>
+>] &
+  hkt.Container<TypeormQueryTypeFactory<TEntities>> & {
+    [ɵtypeormTypes]?: TEntities;
+  };
+
+export type BaseTypeormQuery = Record<string, any>;

--- a/packages/casl-typeorm/tsconfig.build.json
+++ b/packages/casl-typeorm/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig",
+  "exclude": [
+    "spec/**/*"
+  ],
+  "compilerOptions": {
+    "outDir": "dist/types"
+  }
+}

--- a/packages/casl-typeorm/tsconfig.json
+++ b/packages/casl-typeorm/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig",
+  "include": [
+    "src/*",
+    "spec/*"
+  ],
+  "compilerOptions": {
+    "outDir": "dist/types"
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -205,6 +205,31 @@ importers:
         specifier: ^19.0.0
         version: 19.1.1(react@19.1.1)
 
+  packages/casl-typeorm:
+    dependencies:
+      '@ucast/core':
+        specifier: ^1.10.0
+        version: 1.10.2
+      '@ucast/js':
+        specifier: ^3.0.1
+        version: 3.1.0
+    devDependencies:
+      '@casl/ability':
+        specifier: ^6.0.0
+        version: 6.7.5
+      '@casl/dx':
+        specifier: workspace:^1.0.0
+        version: link:../dx
+      '@types/jest':
+        specifier: ^30.0.0
+        version: 30.0.0
+      '@types/node':
+        specifier: ^24.0.0
+        version: 24.10.3
+      typeorm:
+        specifier: ^0.3.0
+        version: 0.3.28(mysql2@3.15.3)
+
   packages/casl-vue:
     devDependencies:
       '@casl/ability':
@@ -2564,6 +2589,9 @@ packages:
   '@sinonjs/fake-timers@13.0.5':
     resolution: {integrity: sha512-36/hTbH2uaWuGVERyC6da9YwGWnzUZXuPro/F2LfsdOsLnCojz/iSH8MxUt/FD2S5XBSVPhmArFUXcpCQ2Hkiw==}
 
+  '@sqltools/formatter@1.2.5':
+    resolution: {integrity: sha512-Uy0+khmZqUrUGm5dmMqVlnvufZRSK0FbYzVgp0UMstm+F5+W2/jnEEQyc9vo1ZR/E5ZI/B1WjjoTqBqwJL6Krw==}
+
   '@standard-schema/spec@1.0.0':
     resolution: {integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==}
 
@@ -3132,9 +3160,17 @@ packages:
   ansicolors@0.3.2:
     resolution: {integrity: sha512-QXu7BPrP29VllRxH8GwB7x5iX5qWKAAMLqKQGWTeLWVlNHNOpVMJ91dsxQAIWXpjuW5wqvxu3Jd/nRjrJ+0pqg==}
 
+  ansis@4.2.0:
+    resolution: {integrity: sha512-HqZ5rWlFjGiV0tDm3UxxgNRqsOTniqoKZu0pIAfh7TZQMGuZK+hH0drySty0si0QXj1ieop4+SkSfPZBPPkHig==}
+    engines: {node: '>=14'}
+
   anymatch@3.1.3:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
     engines: {node: '>= 8'}
+
+  app-root-path@3.1.0:
+    resolution: {integrity: sha512-biN3PwB2gUtjaYy/isrU3aNWI5w+fAfvHkSvCKeQGxhmYpwKFUxudR3Yya+KqVRHBmEDYh+/lTozYCFbmzX4nA==}
+    engines: {node: '>= 6.0.0'}
 
   argparse@1.0.10:
     resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
@@ -3342,6 +3378,9 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
   baseline-browser-mapping@2.9.6:
     resolution: {integrity: sha512-v9BVVpOTLB59C9E7aSnmIF8h7qRsFpx+A2nugVMTszEOMcfjlZMsXRm4LF23I3Z9AJxc8ANpIvzbzONoX9VJlg==}
     hasBin: true
@@ -3409,6 +3448,9 @@ packages:
 
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
+
+  buffer@6.0.3:
+    resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
 
   bundle-name@4.1.0:
     resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
@@ -3745,6 +3787,9 @@ packages:
   dateformat@3.0.3:
     resolution: {integrity: sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==}
 
+  dayjs@1.11.19:
+    resolution: {integrity: sha512-t5EcLVS6QPBNqM2z8fakk/NKel+Xzshgt8FFKAn+qwlD1pzZWxh0nVCrvFK7ZDb6XucZeF9z8C7CBWTRIVApAw==}
+
   debug@2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
     peerDependencies:
@@ -3796,6 +3841,14 @@ packages:
 
   dedent@1.6.0:
     resolution: {integrity: sha512-F1Z+5UCFpmQUzJa11agbyPVMbpgT/qA3/SKyJ1jyBgm7dUcUEa8v9JwDkerSQXfakBwFljIxhOJqGkjUwZ9FSA==}
+    peerDependencies:
+      babel-plugin-macros: ^3.1.0
+    peerDependenciesMeta:
+      babel-plugin-macros:
+        optional: true
+
+  dedent@1.7.1:
+    resolution: {integrity: sha512-9JmrhGZpOlEgOLdQgSm0zxFaYoQon408V1v49aqTWuXENVlnCuY9JBZcXZiCsZQWDjTm5Qf/nIvAy77mXDAjEg==}
     peerDependencies:
       babel-plugin-macros: ^3.1.0
     peerDependenciesMeta:
@@ -4602,6 +4655,9 @@ packages:
     engines: {node: ^10 || ^12 || >= 14}
     peerDependencies:
       postcss: ^8.1.0
+
+  ieee754@1.2.1:
+    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
@@ -6441,6 +6497,11 @@ packages:
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
 
+  sha.js@2.4.12:
+    resolution: {integrity: sha512-8LzC5+bvI45BjpfXU8V5fdU2mfeKiQe1D1gIMn7XUlF3OTUrpdJpPPH4EMAnF0DsHHdSZqCdSss5qCmJKuiO3w==}
+    engines: {node: '>= 0.10'}
+    hasBin: true
+
   shallow-clone@3.0.1:
     resolution: {integrity: sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==}
     engines: {node: '>=8'}
@@ -6577,6 +6638,10 @@ packages:
 
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
+
+  sql-highlight@6.1.0:
+    resolution: {integrity: sha512-ed7OK4e9ywpE7pgRMkMQmZDPKSVdm0oX5IEtZiKnFucSF0zu6c80GZBe38UqHuVhTWJ9xsKgSMjCG2bml86KvA==}
+    engines: {node: '>=14'}
 
   sqlstring@2.3.3:
     resolution: {integrity: sha512-qC9iz2FlN7DQl3+wjwn3802RTyjCx7sDvfQEXchwa6CWOx07/WVfh91gBmQ9fahw8snwGEWU3xGzOt4tFyHLxg==}
@@ -6794,6 +6859,10 @@ packages:
   tmpl@1.0.5:
     resolution: {integrity: sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==}
 
+  to-buffer@1.2.2:
+    resolution: {integrity: sha512-db0E3UJjcFhpDhAF4tLo03oli3pwl3dbnzXOUIlRKrp+ldk/VUxzpWYZENsw2SZiuBjHAk7DfB0VU7NKdpb6sw==}
+    engines: {node: '>= 0.4'}
+
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
@@ -6935,6 +7004,61 @@ packages:
   typed-assert@1.0.9:
     resolution: {integrity: sha512-KNNZtayBCtmnNmbo5mG47p1XsCyrx6iVqomjcZnec/1Y5GGARaxPs6r49RnSPeUP3YjNYiU9sQHAtY4BBvnZwg==}
 
+  typeorm@0.3.28:
+    resolution: {integrity: sha512-6GH7wXhtfq2D33ZuRXYwIsl/qM5685WZcODZb7noOOcRMteM9KF2x2ap3H0EBjnSV0VO4gNAfJT5Ukp0PkOlvg==}
+    engines: {node: '>=16.13.0'}
+    hasBin: true
+    peerDependencies:
+      '@google-cloud/spanner': ^5.18.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
+      '@sap/hana-client': ^2.14.22
+      better-sqlite3: ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0 || ^12.0.0
+      ioredis: ^5.0.4
+      mongodb: ^5.8.0 || ^6.0.0
+      mssql: ^9.1.1 || ^10.0.0 || ^11.0.0 || ^12.0.0
+      mysql2: ^2.2.5 || ^3.0.1
+      oracledb: ^6.3.0
+      pg: ^8.5.1
+      pg-native: ^3.0.0
+      pg-query-stream: ^4.0.0
+      redis: ^3.1.1 || ^4.0.0 || ^5.0.14
+      sql.js: ^1.4.0
+      sqlite3: ^5.0.3
+      ts-node: ^10.7.0
+      typeorm-aurora-data-api-driver: ^2.0.0 || ^3.0.0
+    peerDependenciesMeta:
+      '@google-cloud/spanner':
+        optional: true
+      '@sap/hana-client':
+        optional: true
+      better-sqlite3:
+        optional: true
+      ioredis:
+        optional: true
+      mongodb:
+        optional: true
+      mssql:
+        optional: true
+      mysql2:
+        optional: true
+      oracledb:
+        optional: true
+      pg:
+        optional: true
+      pg-native:
+        optional: true
+      pg-query-stream:
+        optional: true
+      redis:
+        optional: true
+      sql.js:
+        optional: true
+      sqlite3:
+        optional: true
+      ts-node:
+        optional: true
+      typeorm-aurora-data-api-driver:
+        optional: true
+
   typescript-eslint@8.39.0:
     resolution: {integrity: sha512-lH8FvtdtzcHJCkMOKnN73LIn6SLTpoojgJqDAxPm1jCR14eWSGPX8ul/gggBdPMk/d5+u9V854vTYQ8T5jF/1Q==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -7021,6 +7145,10 @@ packages:
   utils-merge@1.0.1:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
     engines: {node: '>= 0.4.0'}
+
+  uuid@11.1.0:
+    resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
+    hasBin: true
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
@@ -7603,7 +7731,7 @@ snapshots:
       '@babel/types': 7.28.5
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
-      debug: 4.4.1
+      debug: 4.4.3
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -9038,7 +9166,7 @@ snapshots:
       '@babel/parser': 7.28.5
       '@babel/template': 7.27.2
       '@babel/types': 7.28.5
-      debug: 4.4.1
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
@@ -10286,6 +10414,8 @@ snapshots:
     dependencies:
       '@sinonjs/commons': 3.0.1
 
+  '@sqltools/formatter@1.2.5': {}
+
   '@standard-schema/spec@1.0.0': {}
 
   '@stylistic/eslint-plugin-js@4.4.1(eslint@9.33.0(jiti@2.6.1))':
@@ -10917,10 +11047,14 @@ snapshots:
 
   ansicolors@0.3.2: {}
 
+  ansis@4.2.0: {}
+
   anymatch@3.1.3:
     dependencies:
       normalize-path: 3.0.0
       picomatch: 2.3.1
+
+  app-root-path@3.1.0: {}
 
   argparse@1.0.10:
     dependencies:
@@ -11323,6 +11457,8 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
+  base64-js@1.5.1: {}
+
   baseline-browser-mapping@2.9.6: {}
 
   batch@0.6.1: {}
@@ -11409,6 +11545,11 @@ snapshots:
   bson@7.0.0: {}
 
   buffer-from@1.1.2: {}
+
+  buffer@6.0.3:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
 
   bundle-name@4.1.0:
     dependencies:
@@ -11787,6 +11928,8 @@ snapshots:
 
   dateformat@3.0.3: {}
 
+  dayjs@1.11.19: {}
+
   debug@2.6.9:
     dependencies:
       ms: 2.0.0
@@ -11815,6 +11958,8 @@ snapshots:
   decode-uri-component@0.2.2: {}
 
   dedent@1.6.0: {}
+
+  dedent@1.7.1: {}
 
   deep-eql@4.1.4:
     dependencies:
@@ -12440,9 +12585,9 @@ snapshots:
 
   flatted@3.3.3: {}
 
-  follow-redirects@1.15.11(debug@4.4.1):
+  follow-redirects@1.15.11(debug@4.4.3):
     optionalDependencies:
-      debug: 4.4.1
+      debug: 4.4.3
 
   for-each@0.3.5:
     dependencies:
@@ -12718,7 +12863,7 @@ snapshots:
   http-proxy-middleware@2.0.9(@types/express@4.17.23):
     dependencies:
       '@types/http-proxy': 1.17.16
-      http-proxy: 1.18.1(debug@4.4.1)
+      http-proxy: 1.18.1(debug@4.4.3)
       is-glob: 4.0.3
       is-plain-obj: 3.0.0
       micromatch: 4.0.8
@@ -12730,18 +12875,18 @@ snapshots:
   http-proxy-middleware@3.0.5:
     dependencies:
       '@types/http-proxy': 1.17.16
-      debug: 4.4.1
-      http-proxy: 1.18.1(debug@4.4.1)
+      debug: 4.4.3
+      http-proxy: 1.18.1(debug@4.4.3)
       is-glob: 4.0.3
       is-plain-object: 5.0.0
       micromatch: 4.0.8
     transitivePeerDependencies:
       - supports-color
 
-  http-proxy@1.18.1(debug@4.4.1):
+  http-proxy@1.18.1(debug@4.4.3):
     dependencies:
       eventemitter3: 4.0.7
-      follow-redirects: 1.15.11(debug@4.4.1)
+      follow-redirects: 1.15.11(debug@4.4.3)
       requires-port: 1.0.0
     transitivePeerDependencies:
       - debug
@@ -12781,6 +12926,8 @@ snapshots:
   icss-utils@5.1.0(postcss@8.5.6):
     dependencies:
       postcss: 8.5.6
+
+  ieee754@1.2.1: {}
 
   ignore@5.3.2: {}
 
@@ -14798,6 +14945,12 @@ snapshots:
 
   setprototypeof@1.2.0: {}
 
+  sha.js@2.4.12:
+    dependencies:
+      inherits: 2.0.4
+      safe-buffer: 5.2.1
+      to-buffer: 1.2.2
+
   shallow-clone@3.0.1:
     dependencies:
       kind-of: 6.0.3
@@ -14928,7 +15081,7 @@ snapshots:
 
   spdy-transport@3.0.0:
     dependencies:
-      debug: 4.4.1
+      debug: 4.4.3
       detect-node: 2.1.0
       hpack.js: 2.1.6
       obuf: 1.1.2
@@ -14939,7 +15092,7 @@ snapshots:
 
   spdy@4.0.2:
     dependencies:
-      debug: 4.4.1
+      debug: 4.4.3
       handle-thing: 2.0.1
       http-deceiver: 1.2.7
       select-hose: 2.0.0
@@ -14960,6 +15113,8 @@ snapshots:
       through: 2.3.8
 
   sprintf-js@1.0.3: {}
+
+  sql-highlight@6.1.0: {}
 
   sqlstring@2.3.3: {}
 
@@ -15172,6 +15327,12 @@ snapshots:
 
   tmpl@1.0.5: {}
 
+  to-buffer@1.2.2:
+    dependencies:
+      isarray: 2.0.5
+      safe-buffer: 5.2.1
+      typed-array-buffer: 1.0.3
+
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
@@ -15316,6 +15477,29 @@ snapshots:
 
   typed-assert@1.0.9: {}
 
+  typeorm@0.3.28(mysql2@3.15.3):
+    dependencies:
+      '@sqltools/formatter': 1.2.5
+      ansis: 4.2.0
+      app-root-path: 3.1.0
+      buffer: 6.0.3
+      dayjs: 1.11.19
+      debug: 4.4.3
+      dedent: 1.7.1
+      dotenv: 16.6.1
+      glob: 10.5.0
+      reflect-metadata: 0.2.2
+      sha.js: 2.4.12
+      sql-highlight: 6.1.0
+      tslib: 2.8.1
+      uuid: 11.1.0
+      yargs: 17.7.2
+    optionalDependencies:
+      mysql2: 3.15.3
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+
   typescript-eslint@8.39.0(eslint@9.33.0(jiti@2.6.1))(typescript@5.9.3):
     dependencies:
       '@typescript-eslint/eslint-plugin': 8.39.0(@typescript-eslint/parser@8.39.0(eslint@9.33.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.33.0(jiti@2.6.1))(typescript@5.9.3)
@@ -15409,6 +15593,8 @@ snapshots:
   util-deprecate@1.0.2: {}
 
   utils-merge@1.0.1: {}
+
+  uuid@11.1.0: {}
 
   uuid@8.3.2: {}
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -42,6 +42,11 @@
       "package-name": "@casl/vue",
       "component": "@casl/vue",
       "changelog-path": "CHANGELOG.md"
+    },
+    "packages/casl-typeorm": {
+      "package-name": "@casl/typeorm",
+      "component": "@casl/typeorm",
+      "changelog-path": "CHANGELOG.md"
     }
   }
 }


### PR DESCRIPTION
In work we use some weird integration that map mongoose to typeORM, so that is an opportunity to make official support for TypeORM. Feel free to change or improve this initial design.