### PR TITLE
Provide access to cannot reason in angular ability service signal

### DIFF
--- a/packages/casl-angular/src/AbilityServiceSignal.ts
+++ b/packages/casl-angular/src/AbilityServiceSignal.ts
@@ -1,5 +1,5 @@
 import { inject, Injectable, OnDestroy, signal } from "@angular/core";
-import { AnyAbility, PureAbility, RawRuleOf } from "@casl/ability";
+import { AnyAbility, ForbiddenError, PureAbility, RawRuleOf } from "@casl/ability";
 
 @Injectable({ providedIn: 'root' })
 export class AbilityServiceSignal<T extends AnyAbility> implements OnDestroy {
@@ -24,6 +24,11 @@ export class AbilityServiceSignal<T extends AnyAbility> implements OnDestroy {
 
   cannot = (...args: Parameters<T['can']>): boolean => {
     return !this.can(...args);
+  };
+
+  cannotReason = (...args: Parameters<T['can']>): ForbiddenError<T> => {
+    this._rules(); // generate side effect for angular to track changes in this signal
+    return ForbiddenError.from(this._ability).unlessCan(...args)
   };
 
   update(rules: T['rules']): void {


### PR DESCRIPTION
Hi - thanks for your nice work!

I wanted to get access to the forbidden reason in the frontend, hence I added a method to the ability service signal. What do you think of it?

---

Additionally I am curious to hear what you think of a signal of the `can` and `cannot` implementation. Instead of

```typescript
  can = (...args: Parameters<T['can']>): boolean => {
    this._rules(); // generate side effect for angular to track changes in this signal
    return this._ability.can(...args);
  };
```

we'd be creating a `computedSignal`:

```typescript
  can = (...args: Parameters<T['can']>): Signal<boolean> => {                                                                           
    return computed(() => {
      this._rules(); // tracked dependency                                                                                              
      return this._ability.can(...args);                                                                                              
    });
  };
```

This would allow the frontend to receive ability changes without running `can` (or an additional `computed` changes on top of `can` in the user's code. 