### PR TITLE
feat: adds why* methods to AbilityServiceSignal

### DIFF
--- a/packages/casl-angular/spec/AbilityServiceSignal.spec.ts
+++ b/packages/casl-angular/spec/AbilityServiceSignal.spec.ts
@@ -1,29 +1,250 @@
-import { Component, DebugElement, inject, Input, Predicate } from '@angular/core'
+import { Component, DebugElement, inject, Input, Predicate, signal, Type } from '@angular/core'
 import { TestBed } from '@angular/core/testing'
-import { createMongoAbility, PureAbility } from '@casl/ability'
+import { createMongoAbility, MongoAbility, PureAbility } from '@casl/ability'
 import { AbilityServiceSignal } from '../src/public'
 import './spec_helper'
 import { createComponent } from './spec_helper'
 
 describe('AbilityServiceSignal', () => {
-  it('allows to use its `can` method in template', async () => {
-    setup()
-    const fixture = createComponent(App, { role: 'admin' })
-    const deleteButton: Predicate<DebugElement> = (d) => d.nativeElement.textContent?.trim() === 'Delete'
-    expect(fixture.debugElement.query(deleteButton)).toBeTruthy()
+  describe('can', () => {
+    it('returns false when no rules are set', () => {
+      const { abilityService } = setup()
+      expect(abilityService.can('read', 'Article')).toBe(false)
+    })
 
-    Object.assign(fixture.componentInstance, { role: 'user' })
-    fixture.detectChanges()
-    expect(fixture.debugElement.query(deleteButton)).toBeFalsy()
+    it('returns true when matching rule exists', () => {
+      const { abilityService } = setup()
+      abilityService.update([{ action: 'read', subject: 'Article' }])
+      expect(abilityService.can('read', 'Article')).toBe(true)
+    })
+
+    it('returns false when action does not match', () => {
+      const { abilityService } = setup()
+      abilityService.update([{ action: 'read', subject: 'Article' }])
+      expect(abilityService.can('delete', 'Article')).toBe(false)
+    })
   })
 
+  describe('cannot', () => {
+    it('returns true when no rules are set', () => {
+      const { abilityService } = setup()
+      expect(abilityService.cannot('read', 'Article')).toBe(true)
+    })
+
+    it('returns false when matching rule exists', () => {
+      const { abilityService } = setup()
+      abilityService.update([{ action: 'read', subject: 'Article' }])
+      expect(abilityService.cannot('read', 'Article')).toBe(false)
+    })
+
+    it('returns true when action does not match', () => {
+      const { abilityService } = setup()
+      abilityService.update([{ action: 'read', subject: 'Article' }])
+      expect(abilityService.cannot('delete', 'Article')).toBe(true)
+    })
+  })
+
+  describe('whyCan', () => {
+    it('returns null when no relevant rule exists', () => {
+      const { abilityService } = setup()
+      expect(abilityService.whyCan('read', 'Article')).toBeNull()
+    })
+
+    it('returns result with reason when rule has reason', () => {
+      const { abilityService } = setup()
+      abilityService.update([{ action: 'read', subject: 'Article', reason: 'allowed by policy' }])
+      const result = abilityService.whyCan('read', 'Article')
+      expect(result).toEqual({ result: true, reason: 'allowed by policy' })
+    })
+
+    it('returns result with undefined reason when rule has no reason', () => {
+      const { abilityService } = setup()
+      abilityService.update([{ action: 'read', subject: 'Article' }])
+      const result = abilityService.whyCan('read', 'Article')
+      expect(result).toEqual({ result: true, reason: undefined })
+    })
+
+    it('returns result false for inverted rule', () => {
+      const { abilityService } = setup()
+      abilityService.update([
+        { action: 'manage', subject: 'all' },
+        { action: 'delete', subject: 'Article', inverted: true, reason: 'forbidden' }
+      ])
+      const result = abilityService.whyCan('delete', 'Article')
+      expect(result).toEqual({ result: false, reason: 'forbidden' })
+    })
+  })
+
+  describe('whyCannot', () => {
+    it('returns null when no relevant rule exists', () => {
+      const { abilityService } = setup()
+      expect(abilityService.whyCannot('read', 'Article')).toBeNull()
+    })
+
+    it('returns inverted result compared to whyCan', () => {
+      const { abilityService } = setup()
+      abilityService.update([{ action: 'read', subject: 'Article', reason: 'allowed by policy' }])
+      const result = abilityService.whyCannot('read', 'Article')
+      expect(result).toEqual({ result: false, reason: 'allowed by policy' })
+    })
+
+    it('returns result true for inverted rule', () => {
+      const { abilityService } = setup()
+      abilityService.update([
+        { action: 'manage', subject: 'all' },
+        { action: 'delete', subject: 'Article', inverted: true, reason: 'forbidden' }
+      ])
+      const result = abilityService.whyCannot('delete', 'Article')
+      expect(result).toEqual({ result: true, reason: 'forbidden' })
+    })
+  })
+
+  describe('deferCan', () => {
+    it('returns a signal that reflects current ability', () => {
+      const { abilityService } = setup()
+      const canRead = abilityService.deferCan('read', 'Article')
+      expect(canRead()).toBe(false)
+
+      abilityService.update([{ action: 'read', subject: 'Article' }])
+      expect(canRead()).toBe(true)
+    })
+
+    it('accepts signal arguments and reacts to their changes', () => {
+      const { abilityService } = setup()
+      abilityService.update([{ action: 'read', subject: 'Article' }])
+      const action = signal<'read' | 'delete'>('read')
+      const canDo = abilityService.deferCan(action, 'Article')
+      expect(canDo()).toBe(true)
+
+      action.set('delete')
+      expect(canDo()).toBe(false)
+    })
+  })
+
+  describe('deferCannot', () => {
+    it('returns a signal that reflects inverse of current ability', () => {
+      const { abilityService } = setup()
+      const cannotRead = abilityService.deferCannot('read', 'Article')
+      expect(cannotRead()).toBe(true)
+
+      abilityService.update([{ action: 'read', subject: 'Article' }])
+      expect(cannotRead()).toBe(false)
+    })
+
+    it('accepts signal arguments and reacts to their changes', () => {
+      const { abilityService } = setup()
+      abilityService.update([{ action: 'read', subject: 'Article' }])
+      const action = signal<'read' | 'delete'>('read')
+      const cannotDo = abilityService.deferCannot(action, 'Article')
+      expect(cannotDo()).toBe(false)
+
+      action.set('delete')
+      expect(cannotDo()).toBe(true)
+    })
+  })
+
+  describe('deferWhyCan', () => {
+    it('returns a signal that reflects whyCan result', () => {
+      const { abilityService } = setup()
+      const result = abilityService.deferWhyCan('read', 'Article')
+      expect(result()).toBeNull()
+
+      abilityService.update([{ action: 'read', subject: 'Article', reason: 'test' }])
+      expect(result()).toEqual({ result: true, reason: 'test' })
+    })
+
+    it('accepts signal arguments', () => {
+      const { abilityService } = setup()
+      abilityService.update([{ action: 'read', subject: 'Article', reason: 'test' }])
+      const action = signal<'read' | 'delete'>('read')
+      const result = abilityService.deferWhyCan(action, 'Article')
+      expect(result()).toEqual({ result: true, reason: 'test' })
+
+      action.set('delete')
+      expect(result()).toBeNull()
+    })
+  })
+
+  describe('deferWhyCannot', () => {
+    it('returns a signal that reflects whyCannot result', () => {
+      const { abilityService } = setup()
+      const result = abilityService.deferWhyCannot('read', 'Article')
+      expect(result()).toBeNull()
+
+      abilityService.update([{ action: 'read', subject: 'Article', reason: 'test' }])
+      expect(result()).toEqual({ result: false, reason: 'test' })
+    })
+
+    it('accepts signal arguments', () => {
+      const { abilityService } = setup()
+      abilityService.update([{ action: 'read', subject: 'Article', reason: 'test' }])
+      const action = signal<'read' | 'delete'>('read')
+      const result = abilityService.deferWhyCannot(action, 'Article')
+      expect(result()).toEqual({ result: false, reason: 'test' })
+
+      action.set('delete')
+      expect(result()).toBeNull()
+    })
+  })
+
+  describe('update', () => {
+    it('updates underlying ability rules', () => {
+      const { abilityService } = setup()
+      expect(abilityService.can('read', 'Article')).toBe(false)
+      abilityService.update([{ action: 'read', subject: 'Article' }])
+      expect(abilityService.can('read', 'Article')).toBe(true)
+    })
+
+    it('replaces previous rules', () => {
+      const { abilityService } = setup()
+      abilityService.update([{ action: 'read', subject: 'Article' }])
+      abilityService.update([{ action: 'delete', subject: 'Article' }])
+      expect(abilityService.can('read', 'Article')).toBe(false)
+      expect(abilityService.can('delete', 'Article')).toBe(true)
+    })
+  })
+
+  describe('ngOnDestroy', () => {
+    it('unsubscribes from ability updates', () => {
+      const { abilityService } = setup()
+      const canRead = abilityService.deferCan('read', 'Article')
+
+      expect(canRead()).toBe(false)
+
+      abilityService.ngOnDestroy()
+      abilityService.update([{ action: 'read', subject: 'Article' }])
+      // The deferred signal won't reflect updates made after destroy
+      // because the internal _rules signal is no longer updated via subscription
+      expect(canRead()).toBe(false)
+    })
+  })
+
+  describe('template integration', () => {
+    it('allows to use its `can` method in template', async () => {
+      setup()
+      const fixture = createComponent(App, { role: 'admin' })
+      const deleteButton: Predicate<DebugElement> = (d) => d.nativeElement.textContent?.trim() === 'Delete'
+      expect(fixture.debugElement.query(deleteButton)).toBeTruthy()
+
+      Object.assign(fixture.componentInstance, { role: 'user' })
+      fixture.detectChanges()
+      expect(fixture.debugElement.query(deleteButton)).toBeFalsy()
+    })
+  })
+
+  type AppAbility = MongoAbility<['read' | 'manage' | 'delete', 'all' | 'Article' | { kind: 'Article'; id: number }]>
   function setup() {
+    const ability = createMongoAbility<AppAbility>()
     TestBed.configureTestingModule({
       providers: [
         AbilityServiceSignal,
-        { provide: PureAbility, useValue: createMongoAbility() }
+        { provide: PureAbility, useValue: ability }
       ]
     })
+    const abilityService = TestBed.inject(
+      AbilityServiceSignal as Type<AbilityServiceSignal<AppAbility>>
+    )
+    return { ability, abilityService }
   }
 
   @Component({
@@ -38,7 +259,7 @@ describe('AbilityServiceSignal', () => {
     `
   })
   class App {
-    @Input() 
+    @Input()
     set role(value: 'admin' | 'user') {
       if (value === 'admin') {
         this.abilityService.update([{ action: 'manage', subject: 'all' }])
@@ -47,7 +268,7 @@ describe('AbilityServiceSignal', () => {
       }
     }
 
-    private readonly abilityService = inject(AbilityServiceSignal)
+    private readonly abilityService = inject<AbilityServiceSignal<AppAbility>>(AbilityServiceSignal)
     protected can = this.abilityService.can
   }
 })

--- a/packages/casl-angular/src/AbilityServiceSignal.ts
+++ b/packages/casl-angular/src/AbilityServiceSignal.ts
@@ -1,4 +1,4 @@
-import { inject, Injectable, OnDestroy, signal } from "@angular/core";
+import { computed, inject, Injectable, isSignal, OnDestroy, signal, Signal } from "@angular/core";
 import { AnyAbility, PureAbility, RawRuleOf } from "@casl/ability";
 
 @Injectable({ providedIn: 'root' })
@@ -17,16 +17,59 @@ export class AbilityServiceSignal<T extends AnyAbility> implements OnDestroy {
     this._disposeAbilitySubscription();
   }
 
-  can = (...args: Parameters<T['can']>): boolean => {
+  private _getReactiveAbility(): T {
     this._rules(); // generate side effect for angular to track changes in this signal
-    return this._ability.can(...args);
+    return this._ability;
+  }
+
+  can = (...args: Parameters<T['can']>): boolean => {
+    return this._getReactiveAbility().can(...args);
   };
 
   cannot = (...args: Parameters<T['can']>): boolean => {
     return !this.can(...args);
   };
 
+  deferCan(...args: WithSignals<Parameters<T['can']>>): Signal<boolean> {
+    return computed(() => this.can(...unwrapSignals(args)));
+  }
+
+  deferCannot(...args: WithSignals<Parameters<T['can']>>): Signal<boolean> {
+    return computed(() => this.cannot(...unwrapSignals(args)));
+  }
+
+  whyCan = (...args: Parameters<T['can']>): ResultWithReason | null => {
+    const rule = this._getReactiveAbility().relevantRuleFor(...args);
+    if (!rule) return null;
+    return { result: !rule.inverted, reason: rule.reason };
+  };
+
+  whyCannot = (...args: Parameters<T['can']>): ResultWithReason | null => {
+    const result = this.whyCan(...args);
+    if (!result) return null;
+    result.result = !result.result;
+    return result;
+  };
+
+  deferWhyCan(...args: WithSignals<Parameters<T['can']>>): Signal<ResultWithReason | null> {
+    return computed(() => this.whyCan(...unwrapSignals(args)));
+  }
+
+  deferWhyCannot(...args: WithSignals<Parameters<T['can']>>): Signal<ResultWithReason | null> {
+    return computed(() => this.whyCannot(...unwrapSignals(args)));
+  }
+
   update(rules: T['rules']): void {
     this._ability.update(rules);
   }
+}
+
+export interface ResultWithReason {
+  result: boolean;
+  reason: string | undefined;
+}
+
+type WithSignals<T extends any[]> = { [K in keyof T]: T[K] | Signal<T[K]> };
+function unwrapSignals<T extends any[]>(args: WithSignals<T>): T {
+  return args.map(arg => isSignal(arg) ? arg() : arg) as T;
 }

--- a/packages/casl-angular/tsconfig.json
+++ b/packages/casl-angular/tsconfig.json
@@ -17,7 +17,8 @@
     "lib": [
       "es2019",
       "dom"
-    ]
+    ],
+    "types": ["jest"]
   },
   "include": [
     "src/*",


### PR DESCRIPTION
## Why

`AbilityServiceSignal` only exposed `can`, and `update`. Users had no way to get rule reasons, or use reactive reason-based signals — forcing workarounds or falling back to the underlying ability directly.

Original request: https://github.com/stalniy/casl/pull/1185

## What

Expanded the public interface of `AbilityServiceSignal` with the following method pairs:

- **`whyCan` / `whyCannot`** — permission checks with reason
  ```ts
  abilityService.whyCan('read', 'Article')    // { result: true, reason: 'allowed by policy' }
  abilityService.whyCannot('read', 'Article') // { result: false, reason: 'allowed by policy' }
  ```
- **`deferCan` / `deferCannot`** — reactive signals that accept plain values or signals as arguments
  ```ts
  @Component({
    template: `
      @if (canDeleteArticle()) {
        <button>Delete</button>
      }
    `
  })
  class App {
    private abilityService = inject<AbilityServiceSignal<AppAbility>>(AbilityServiceSignal)
    readonly canDeleteArticle = this.abilityService.deferCan('delete', 'Article')
  }
  ```
- **`deferWhyCan` / `deferWhyCannot`** — reactive signals with rule reason
  ```ts
  @Component({
    template: `
      @if (!canDeleteArticle()?.result) {
        <p>{{ canDeleteArticle().reason }}</p>
      }
    `
  })
  class App {
    private abilityService = inject<AbilityServiceSignal<AppAbility>>(AbilityServiceSignal)
    canDeleteArticle = this.abilityService.deferWhyCan('delete', 'Article')
  }
  ```

All `defer*` methods accept `Signal` arguments, enabling reactive permission checks that update when both rules and arguments change.