### PR TITLE
perf: lazily create a new array during rule field filtering

### DIFF
--- a/packages/casl-ability/src/RuleIndex.ts
+++ b/packages/casl-ability/src/RuleIndex.ts
@@ -8,7 +8,7 @@ import {
   AbilityTuple,
   ExtractSubjectType
 } from './types';
-import { wrapArray, detectSubjectType, mergePrioritized, getOrDefault, identity, isSubjectType, DETECT_SUBJECT_TYPE_STRATEGY } from './utils';
+import { wrapArray, detectSubjectType, mergePrioritized, getOrDefault, identity, isSubjectType, DETECT_SUBJECT_TYPE_STRATEGY, filterWithLazyAllocation } from './utils';
 import { LinkedItem, linkedItem, unlinkItem } from './structures/LinkedItem';
 
 export interface RuleIndexOptions<A extends Abilities, C> extends Partial<RuleOptions<C>> {
@@ -219,7 +219,7 @@ export class RuleIndex<A extends Abilities, Conditions> {
       return rules;
     }
 
-    return rules.filter(rule => rule.matchesField(field));
+    return filterWithLazyAllocation(rules, rule => rule.matchesField(field));
   }
 
   actionsFor(subjectType: ExtractSubjectType<Normalize<A>[1]>): string[] {

--- a/packages/casl-ability/src/utils.ts
+++ b/packages/casl-ability/src/utils.ts
@@ -183,3 +183,18 @@ export function getOrDefault<K, V>(map: Map<K, V>, key: K, defaultValue: () => V
 }
 
 export const identity = <T>(x: T) => x;
+
+export function filterWithLazyAllocation<T>(array: T[], predicate: (item: T) => boolean): T[] {
+  let result: T[] | undefined;
+  for (let i = 0; i < array.length; i++) {
+    const matches = predicate(array[i]);
+    if (result && matches) {
+      result.push(array[i]);
+    }
+    if (!matches) {
+      result ??= array.slice(0, i);
+    }
+  }
+
+  return result || array;
+}


### PR DESCRIPTION
## Why

to reduce GC calls and unnecessary memory allocation