### PR TITLE
fix: treats empty conditions object as matches all

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,6 +53,7 @@ jobs:
           pnpm run -r --filter '...[${{ steps.base-commit.outputs.sha }}]' test --coverage
         fi
     - name: Submit coverage
+      if: matrix.node == 'latest'
       uses: codecov/codecov-action@v5
       with:
         fail_ci_if_error: true

--- a/packages/casl-ability/spec/ability.spec.ts
+++ b/packages/casl-ability/spec/ability.spec.ts
@@ -324,6 +324,16 @@ describe('Ability', () => {
       expect(ability.can('delete', 'Post')).toBe(false)
       expect(ability.can('delete', 'User')).toBe(true)
     })
+
+    it('treats empty conditions as always matching', () => {
+      const ability = defineAbility((can, cannot) => {
+        can('manage', 'User', {})
+        cannot('update', 'User', ['admin'], {})
+      })
+
+      expect(ability.can('update', 'User', 'admin')).toBe(false)
+      expect(ability.can('update', 'User', 'name')).toBe(true)
+    })
   })
 
   describe('rule conditions', () => {

--- a/packages/casl-ability/src/Rule.ts
+++ b/packages/casl-ability/src/Rule.ts
@@ -8,7 +8,8 @@ import {
   ConditionsMatcher,
   FieldMatcher,
 } from './types';
-import { RawRule, RawRuleFrom } from './RawRule';
+import type { RawRule, RawRuleFrom } from './RawRule';
+import type { Condition } from '@ucast/mongo2js';
 
 type Tuple<A extends Abilities> = Normalize<ToAbilityTypes<A>>;
 
@@ -82,11 +83,12 @@ export class Rule<A extends Abilities, C> {
     }
 
     if (!object || isSubjectType(object)) {
-      return !this.inverted;
+      if (!this.inverted) return true;
+      const matches = this._conditionsMatcher();
+      return matches.matchesAll === true || !!matches.ast && isMatchesAll(matches.ast);
     }
 
-    const matches = this._conditionsMatcher();
-    return matches(object as Record<string, unknown>);
+    return this._conditionsMatcher()(object as Record<string, unknown>);
   }
 
   matchesField(field: string | undefined): boolean {
@@ -106,4 +108,10 @@ export class Rule<A extends Abilities, C> {
 
     return this._matchField(field);
   }
+}
+
+function isMatchesAll(ast: Condition): boolean {
+  return (ast.operator === 'and' || ast.operator === 'AND') &&
+    Array.isArray(ast.value) &&
+    ast.value.length === 0;
 }

--- a/packages/casl-ability/src/types.ts
+++ b/packages/casl-ability/src/types.ts
@@ -70,6 +70,7 @@ interface MatchConditionsFactory extends GenericFactory<{}> {
 export type MatchConditions<T extends {} = AnyRecord> = Container<MatchConditionsFactory> & {
   (object: T): boolean
   ast?: Condition
+  matchesAll?: boolean
 };
 export type ConditionsMatcher<T> = (conditions: T) => MatchConditions;
 export type MatchField<T extends string> = (field: T) => boolean;

--- a/packages/casl-ability/tsconfig.json
+++ b/packages/casl-ability/tsconfig.json
@@ -3,5 +3,8 @@
   "include": [
     "src/**/*",
     "spec/**/*"
-  ]
+  ],
+  "compilerOptions": {
+    "types": ["jest", "node"]
+  }
 }


### PR DESCRIPTION
## Why

Currently ability matching logic doesn't distinguish between no conditions and conditions that semantically match everything. As a result

```ts
can('manage', 'User', {})
cannot('update', 'User', ['admin'], {})
```

treated differently from (when checking `ability.can('update', 'User', 'admin')`

```ts
can('manage', 'User')
cannot('update', 'User', ['admin'])
```

but semantically they are the same!

This is a bug fix but potentially may break expectations for existing users, so will be released as a BREAKING CHANGE

Closes #684

## What

treats empty conditions object as matches all