### PR TITLE
refactor: removes `getDefaultErrorMessage` exported function as unneeded

### DIFF
--- a/packages/casl-ability/spec/error.spec.ts
+++ b/packages/casl-ability/spec/error.spec.ts
@@ -1,4 +1,4 @@
-import { ForbiddenError, getDefaultErrorMessage, Ability, SubjectType } from '../src'
+import { ForbiddenError, Ability, SubjectType } from '../src'
 
 describe('`ForbiddenError` class', () => {
   describe('`throwUnlessCan` method', () => {
@@ -69,7 +69,7 @@ describe('`ForbiddenError` class', () => {
 
   describe('`setDefaultMessage` method', () => {
     afterEach(() => {
-      ForbiddenError.setDefaultMessage(getDefaultErrorMessage)
+      ForbiddenError.setDefaultMessage(ForbiddenError._defaultErrorMessage)
     })
 
     it('sets default message from function', () => {

--- a/packages/casl-ability/src/ForbiddenError.ts
+++ b/packages/casl-ability/src/ForbiddenError.ts
@@ -4,8 +4,6 @@ import type { Generics } from './RuleIndex';
 import { getSubjectTypeName } from './utils';
 
 export type GetErrorMessage = (error: ForbiddenError<AnyAbility>) => string;
-/** @deprecated will be removed in the next major release */
-export const getDefaultErrorMessage: GetErrorMessage = error => `Cannot execute "${error.action}" on "${error.subjectType}"`;
 
 const NativeError = function NError(this: Error, message: string) {
   this.message = message;
@@ -20,7 +18,7 @@ export class ForbiddenError<T extends AnyAbility> extends NativeError {
   public field?: string;
   public subjectType!: string;
 
-  static _defaultErrorMessage = getDefaultErrorMessage;
+  static _defaultErrorMessage: GetErrorMessage = error => `Cannot execute "${error.action}" on "${error.subjectType}"`
 
   static setDefaultMessage(messageOrFn: string | GetErrorMessage) {
     this._defaultErrorMessage = typeof messageOrFn === 'string' ? () => messageOrFn : messageOrFn;


### PR DESCRIPTION
BREAKING CHANGE: this function is unused in userland and mostly was needed to restore ForbiddenError state in tests