### PR TITLE
refactor: migrates mongoose subpackage to @casl/ability@7.x

### DIFF
--- a/packages/casl-mongoose/package.json
+++ b/packages/casl-mongoose/package.json
@@ -3,8 +3,6 @@
   "version": "8.0.5",
   "description": "Allows to query accessible records from MongoDB based on CASL rules",
   "main": "./dist/cjs/index.cjs",
-  "module": "./dist/esm/index.mjs",
-  "types": "./dist/types/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/types/index.d.ts",
@@ -39,11 +37,11 @@
   "author": "Sergii Stotskyi <sergiy.stotskiy@gmail.com>",
   "license": "MIT",
   "peerDependencies": {
-    "@casl/ability": "^6.7.0",
+    "@casl/ability": "^7.0.0",
     "mongoose": "^6.0.13 || ^7.0.0 || ^8.0.0 || ^9.0.0"
   },
   "devDependencies": {
-    "@casl/ability": "^6.0.0",
+    "@casl/ability": "workspace:*",
     "@casl/dx": "workspace:^1.0.0",
     "@types/jest": "^30.0.0",
     "@types/node": "^24.0.0",

--- a/packages/casl-mongoose/spec/accessibleBy.spec.ts
+++ b/packages/casl-mongoose/spec/accessibleBy.spec.ts
@@ -35,120 +35,126 @@ describe('accessibleBy', () => {
     expect(query).toEqual({ $expr: { $eq: [0, 1] } })
   })
 
-  describe('it behaves like `toMongoQuery` when converting rules', () => {
-    it('accepts ability action as third argument', () => {
-      const ability = defineAbility<AppAbility>((can) => {
-        can('update', 'Post', { _id: 'mega' })
-      })
-      const query = accessibleBy(ability, 'update').ofType('Post')
+  it('accepts ability action as third argument', () => {
+    const ability = defineAbility<AppAbility>((can) => {
+      can('update', 'Post', { _id: 'mega' })
+    })
+    const query = accessibleBy(ability, 'update').ofType('Post')
 
-      expect(query).toEqual({
-        $or: [{ _id: 'mega' }]
+    expect(query).toEqual({
+      $or: [{ _id: 'mega' }]
+    })
+  })
+
+  it('OR-es conditions for regular rules and AND-es for inverted ones', () => {
+    const ability = defineAbility<AppAbility>((can, cannot) => {
+      can('read', 'Post', { _id: 'mega' })
+      can('read', 'Post', { state: 'draft' })
+      cannot('read', 'Post', { private: true })
+      cannot('read', 'Post', { state: 'archived' })
+    })
+    const query = accessibleBy(ability).ofType('Post')
+
+    expect(query).toEqual({
+      $or: [
+        {
+          $and: [
+            { state: 'draft' },
+            { $nor: [{ state: 'archived' }] },
+            { $nor: [{ private: true }] }
+          ]
+        },
+        {
+          $and: [
+            { _id: 'mega' },
+            { $nor: [{ state: 'archived' }] },
+            { $nor: [{ private: true }] }
+          ]
+        }
+      ]
+    })
+  })
+
+  describe('can find records where property', () => {
+    it('is present', () => {
+      const ability = defineAbility<AppAbility>((can) => {
+        can('read', 'Post', {
+          isPublished: { $exists: true, $ne: null }
+        })
       })
+      const query = accessibleBy(ability).ofType('Post')
+
+      expect(query).toEqual({ $or: [{ isPublished: { $exists: true, $ne: null } }] })
     })
 
-    it('OR-es conditions for regular rules and AND-es for inverted ones', () => {
-      const ability = defineAbility<AppAbility>((can, cannot) => {
-        can('read', 'Post', { _id: 'mega' })
-        can('read', 'Post', { state: 'draft' })
-        cannot('read', 'Post', { private: true })
-        cannot('read', 'Post', { state: 'archived' })
+    it('is blank', () => {
+      const ability = defineAbility<AppAbility>((can) => {
+        can('read', 'Post', { isPublished: { $exists: false } })
+        can('read', 'Post', { isPublished: null })
       })
       const query = accessibleBy(ability).ofType('Post')
 
       expect(query).toEqual({
         $or: [
-          { state: 'draft' },
-          { _id: 'mega' }
-        ],
-        $and: [
-          { $nor: [{ state: 'archived' }] },
-          { $nor: [{ private: true }] }
+          { isPublished: null },
+          { isPublished: { $exists: false } }
         ]
       })
     })
 
-    describe('can find records where property', () => {
-      it('is present', () => {
-        const ability = defineAbility<AppAbility>((can) => {
-          can('read', 'Post', {
-            isPublished: { $exists: true, $ne: null }
-          })
-        })
-        const query = accessibleBy(ability).ofType('Post')
-
-        expect(query).toEqual({ $or: [{ isPublished: { $exists: true, $ne: null } }] })
+    it('is defined by `$in` criteria', () => {
+      const ability = defineAbility<AppAbility>((can) => {
+        can('read', 'Post', { state: { $in: ['draft', 'archived'] } })
       })
+      const query = accessibleBy(ability).ofType('Post')
 
-      it('is blank', () => {
-        const ability = defineAbility<AppAbility>((can) => {
-          can('read', 'Post', { isPublished: { $exists: false } })
-          can('read', 'Post', { isPublished: null })
-        })
-        const query = accessibleBy(ability).ofType('Post')
+      expect(query).toEqual({ $or: [{ state: { $in: ['draft', 'archived'] } }] })
+    })
 
-        expect(query).toEqual({
-          $or: [
-            { isPublished: null },
-            { isPublished: { $exists: false } }
-          ]
-        })
+    it('is defined by `$all` criteria', () => {
+      const ability = defineAbility<AppAbility>((can) => {
+        can('read', 'Post', { state: { $all: ['draft', 'archived'] } })
       })
+      const query = accessibleBy(ability).ofType('Post')
 
-      it('is defined by `$in` criteria', () => {
-        const ability = defineAbility<AppAbility>((can) => {
-          can('read', 'Post', { state: { $in: ['draft', 'archived'] } })
-        })
-        const query = accessibleBy(ability).ofType('Post')
-
-        expect(query).toEqual({ $or: [{ state: { $in: ['draft', 'archived'] } }] })
+      expect(query).toEqual({ $or: [{ state: { $all: ['draft', 'archived'] } }] })
+    })
+    it('is defined by `$lt` and `$lte` criteria', () => {
+      const ability = defineAbility<AppAbility>((can) => {
+        can('read', 'Post', { views: { $lt: 10 } })
+        can('read', 'Post', { views: { $lt: 5 } })
       })
+      const query = accessibleBy(ability).ofType('Post')
 
-      it('is defined by `$all` criteria', () => {
-        const ability = defineAbility<AppAbility>((can) => {
-          can('read', 'Post', { state: { $all: ['draft', 'archived'] } })
-        })
-        const query = accessibleBy(ability).ofType('Post')
+      expect(query).toEqual({ $or: [{ views: { $lt: 5 } }, { views: { $lt: 10 } }] })
+    })
 
-        expect(query).toEqual({ $or: [{ state: { $all: ['draft', 'archived'] } }] })
+    it('is defined by `$gt` and `$gte` criteria', () => {
+      const ability = defineAbility<AppAbility>((can) => {
+        can('read', 'Post', { views: { $gt: 10 } })
+        can('read', 'Post', { views: { $gte: 100 } })
       })
-      it('is defined by `$lt` and `$lte` criteria', () => {
-        const ability = defineAbility<AppAbility>((can) => {
-          can('read', 'Post', { views: { $lt: 10 } })
-          can('read', 'Post', { views: { $lt: 5 } })
-        })
-        const query = accessibleBy(ability).ofType('Post')
+      const query = accessibleBy(ability).ofType('Post')
 
-        expect(query).toEqual({ $or: [{ views: { $lt: 5 } }, { views: { $lt: 10 } }] })
+      expect(query).toEqual({ $or: [{ views: { $gte: 100 } }, { views: { $gt: 10 } }] })
+    })
+
+    it('is defined by `$ne` criteria', () => {
+      const ability = defineAbility<AppAbility>((can) => {
+        can('read', 'Post', { authorId: { $ne: 5 } })
       })
+      const query = accessibleBy(ability).ofType('Post')
 
-      it('is defined by `$gt` and `$gte` criteria', () => {
-        const ability = defineAbility<AppAbility>((can) => {
-          can('read', 'Post', { views: { $gt: 10 } })
-          can('read', 'Post', { views: { $gte: 100 } })
-        })
-        const query = accessibleBy(ability).ofType('Post')
+      expect(query).toEqual({ $or: [{ authorId: { $ne: 5 } }] })
+    })
 
-        expect(query).toEqual({ $or: [{ views: { $gte: 100 } }, { views: { $gt: 10 } }] })
+    it('is defined by dot notation fields', () => {
+      const ability = defineAbility<AppAbility>((can) => {
+        can('read', 'Post', { 'comments.author': 'Ted' })
       })
+      const query = accessibleBy(ability).ofType('Post')
 
-      it('is defined by `$ne` criteria', () => {
-        const ability = defineAbility<AppAbility>((can) => {
-          can('read', 'Post', { authorId: { $ne: 5 } })
-        })
-        const query = accessibleBy(ability).ofType('Post')
-
-        expect(query).toEqual({ $or: [{ authorId: { $ne: 5 } }] })
-      })
-
-      it('is defined by dot notation fields', () => {
-        const ability = defineAbility<AppAbility>((can) => {
-          can('read', 'Post', { 'comments.author': 'Ted' })
-        })
-        const query = accessibleBy(ability).ofType('Post')
-
-        expect(query).toEqual({ $or: [{ 'comments.author': 'Ted' }] })
-      })
+      expect(query).toEqual({ $or: [{ 'comments.author': 'Ted' }] })
     })
   })
 })

--- a/packages/casl-mongoose/spec/accessible_records.spec.ts
+++ b/packages/casl-mongoose/spec/accessible_records.spec.ts
@@ -1,4 +1,4 @@
-import { Ability, defineAbility, SubjectType } from '@casl/ability'
+import { MongoAbility, defineAbility, SubjectType } from '@casl/ability'
 import mongoose from 'mongoose'
 import { accessibleBy, AccessibleRecordModel, accessibleRecordsPlugin } from '../src'
 
@@ -11,7 +11,7 @@ describe('Accessible Records Plugin', () => {
     title: String,
     state: String
   })
-  let ability: Ability
+  let ability: MongoAbility
   // eslint-disable-next-line @typescript-eslint/no-redeclare
   let Post: AccessibleRecordModel<Post>
 
@@ -37,7 +37,7 @@ describe('Accessible Records Plugin', () => {
 
   describe('`accessibleBy` method', () => {
     beforeEach(() => {
-      ability = defineAbility<Ability>((can) => {
+      ability = defineAbility<MongoAbility>((can) => {
         can('read', 'Post', { state: 'draft' })
         can('update', 'Post', { state: 'published' })
       })
@@ -90,7 +90,7 @@ describe('Accessible Records Plugin', () => {
     })
 
     it('returns query for Ability that uses classes as subject type', () => {
-      ability = defineAbility<Ability>((can) => {
+      ability = defineAbility<MongoAbility>((can) => {
         can('read', Post, { state: 'draft' })
         can('update', Post, { state: 'published' })
       }, {

--- a/packages/casl-mongoose/src/accessibleBy.ts
+++ b/packages/casl-mongoose/src/accessibleBy.ts
@@ -1,10 +1,16 @@
-import { AnyMongoAbility, Generics, SubjectType, Abilities, AbilityTuple, ExtractSubjectType } from '@casl/ability';
-import { rulesToQuery } from '@casl/ability/extra';
+import type { AnyMongoAbility, Generics, SubjectType, Abilities, AbilityTuple, ExtractSubjectType } from '@casl/ability';
+import { rulesToCondition } from '@casl/ability/extra';
 
 function convertToMongoQuery(rule: AnyMongoAbility['rules'][number]) {
   const conditions = rule.conditions!;
   return rule.inverted ? { $nor: [conditions] } : conditions;
 }
+
+const MONGO_QUERY_AGGREGATION = {
+  and: (conditions: unknown[]) => ({ $and: conditions }),
+  or: (conditions: unknown[]) => ({ $or: conditions }),
+  empty: () => ({})
+};
 
 export const EMPTY_RESULT_QUERY = { $expr: { $eq: [0, 1] } };
 export class AccessibleRecords<T extends SubjectType> {
@@ -17,7 +23,8 @@ export class AccessibleRecords<T extends SubjectType> {
    * In case action is not allowed, it returns `{ $expr: { $eq: [0, 1] } }`
    */
   ofType(subjectType: T): Record<string, unknown> {
-    const query = rulesToQuery(this._ability, this._action, subjectType, convertToMongoQuery);
+    const rules = this._ability.rulesFor(this._action, subjectType);
+    const query = rulesToCondition(rules, convertToMongoQuery, MONGO_QUERY_AGGREGATION);
     return query === null ? EMPTY_RESULT_QUERY : query as Record<string, unknown>;
   }
 }

--- a/packages/casl-mongoose/src/accessibleFieldsBy.ts
+++ b/packages/casl-mongoose/src/accessibleFieldsBy.ts
@@ -1,5 +1,5 @@
-import { AnyMongoAbility, Generics } from "@casl/ability";
-import { AccessibleFields, GetSubjectTypeAllFieldsExtractor } from "@casl/ability/extra";
+import type { AnyMongoAbility, Generics } from "@casl/ability";
+import { AccessibleFields, type GetSubjectTypeAllFieldsExtractor } from "@casl/ability/extra";
 import mongoose from 'mongoose';
 
 const getSubjectTypeAllFieldsExtractor: GetSubjectTypeAllFieldsExtractor = (type) => {

--- a/packages/casl-mongoose/src/plugins/accessible_fields.ts
+++ b/packages/casl-mongoose/src/plugins/accessible_fields.ts
@@ -1,5 +1,5 @@
-import { AnyMongoAbility, Generics, Normalize, wrapArray } from '@casl/ability';
-import { AccessibleFields, GetSubjectTypeAllFieldsExtractor } from '@casl/ability/extra';
+import { type AnyMongoAbility, type Generics, type Normalize, wrapArray } from '@casl/ability';
+import { AccessibleFields, type GetSubjectTypeAllFieldsExtractor } from '@casl/ability/extra';
 import type { Document as Doc, Model, Schema } from 'mongoose';
 
 export type AccessibleFieldsOptions =

--- a/packages/casl-mongoose/src/plugins/accessible_records.ts
+++ b/packages/casl-mongoose/src/plugins/accessible_records.ts
@@ -1,4 +1,4 @@
-import { AnyMongoAbility, Generics, Normalize } from '@casl/ability';
+import type { AnyMongoAbility, Generics, Normalize } from '@casl/ability';
 import type { Document as Doc, HydratedDocument, Model, Query, QueryWithHelpers, Schema } from 'mongoose';
 import { accessibleBy } from '../accessibleBy';
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -126,8 +126,8 @@ importers:
   packages/casl-mongoose:
     devDependencies:
       '@casl/ability':
-        specifier: ^6.0.0
-        version: 6.7.5
+        specifier: workspace:*
+        version: link:../casl-ability
       '@casl/dx':
         specifier: workspace:^1.0.0
         version: link:../dx


### PR DESCRIPTION
BREAKING CHANGE: replaces rulesToQuery with rulesToCondition which produces a different query shape