### PR TITLE
refactor: migrates to @casl/ability 7.x

### DIFF
--- a/packages/casl-prisma/README.md
+++ b/packages/casl-prisma/README.md
@@ -27,10 +27,10 @@ This package is a bit different from all others because it provides a custom `cr
 
 ```ts
 import { User, Post, Prisma } from '@prisma/client';
-import { PureAbility, AbilityBuilder, subject } from '@casl/ability';
+import { Ability, AbilityBuilder, subject } from '@casl/ability';
 import { createPrismaAbility, PrismaQuery, Subjects } from '@casl/prisma';
 
-type AppAbility = PureAbility<[string, Subjects<{
+type AppAbility = Ability<[string, Subjects<{
   User: User,
   Post: Post
 }>], PrismaQuery>;
@@ -186,7 +186,7 @@ type AppSubjects = 'all' | Subjects<{
   User: User
 }>; // 'User' | Model<User, 'User'>
 
-type AppAbility = PureAbility<[string, AppSubjects], PrismaQuery>;
+type AppAbility = Ability<[string, AppSubjects], PrismaQuery>;
 ```
 
 ## Custom PrismaClient output path (Prisma 7 default)
@@ -236,7 +236,7 @@ export type AppSubjects = Subjects<{
   Post: Post,
 }>;
 
-export type AppAbility = PureAbility<['create' | "read" | "update" | "delete", 'all' | AppSubjects], PrismaQuery>
+export type AppAbility = Ability<['create' | "read" | "update" | "delete", 'all' | AppSubjects], PrismaQuery>
 ```
 
 Use this wrapper in your app instead of importing from `@casl/prisma` directly. If you stay on the legacy `prisma-client-js` generator for Prisma 6.x compatibility, the default `@casl/prisma` entrypoint keeps working.

--- a/packages/casl-prisma/package.json
+++ b/packages/casl-prisma/package.json
@@ -43,11 +43,11 @@
   "author": "Sergii Stotskyi <sergiy.stotskiy@gmail.com>",
   "license": "MIT",
   "peerDependencies": {
-    "@casl/ability": "^5.3.0 || ^6.0.0",
+    "@casl/ability": "^7.0.0",
     "@prisma/client": "^4.16.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
   },
   "devDependencies": {
-    "@casl/ability": "^6.0.0",
+    "@casl/ability": "workspace:*",
     "@casl/dx": "workspace:^1.0.0",
     "@prisma/adapter-better-sqlite3": "^7.7.0",
     "@prisma/client": "^7.0.0",

--- a/packages/casl-prisma/spec/AppAbility.ts
+++ b/packages/casl-prisma/spec/AppAbility.ts
@@ -1,8 +1,8 @@
-import { PureAbility } from '@casl/ability'
+import { Ability } from '@casl/ability'
 import type { User, Post } from '@prisma/client'
 import type { PrismaQuery, Subjects } from '../src'
 
-export type AppAbility = PureAbility<['create' | "read" | "update" | "delete", 'all' | Subjects<{
+export type AppAbility = Ability<['create' | "read" | "update" | "delete", 'all' | Subjects<{
   User: User,
   Post: Post
 }>], PrismaQuery>

--- a/packages/casl-prisma/spec/accessibleBy.spec.ts
+++ b/packages/casl-prisma/spec/accessibleBy.spec.ts
@@ -25,28 +25,38 @@ describe('accessibleBy', () => {
     expect(query).toEqual({ OR: [] })
   })
 
-  it('wraps inverted rules in `NOT` operator', () => {
+  it('bounds allowed branches with inverted rules wrapped in `NOT`', () => {
     const query = accessibleBy(ability).ofType('Post')
 
-    expect(query.AND).toEqual([{
-      NOT: {
-        title: { startsWith: '[WIP]:' }
-      }
-    }])
-  })
-
-  it('wraps regular rules in OR and inverted ones in AND', () => {
-    const query = accessibleBy(ability).ofType('Post')
-
-    expect(query).toEqual({
+    expect(query.OR).toEqual([{
       AND: [{
+        id: 1
+      }, {
         NOT: {
           title: { startsWith: '[WIP]:' }
         }
-      }],
-      OR: [{
-        id: 1
       }]
+    }])
+  })
+
+  it('wraps all accessible branches in `OR`', () => {
+    const query = accessibleBy(ability).ofType('Post')
+
+    expect(query).toEqual({
+      OR: [
+        {
+          AND: [
+            {
+              id: 1
+            },
+            {
+              NOT: {
+                title: { startsWith: '[WIP]:' }
+              }
+            }
+          ]
+        }
+      ]
     })
   })
 })

--- a/packages/casl-prisma/spec/createPrismaAbility.spec.ts
+++ b/packages/casl-prisma/spec/createPrismaAbility.spec.ts
@@ -1,4 +1,4 @@
-import { AbilityBuilder, PureAbility, subject } from '@casl/ability'
+import { AbilityBuilder, Ability, subject } from '@casl/ability'
 import { User, Post, Prisma } from '@prisma/client'
 import { createPrismaAbility, Model as M, PrismaQuery, Subjects } from '../src'
 import { AppAbility } from './AppAbility'
@@ -52,7 +52,7 @@ describe(createPrismaAbility.name, () => {
           action: 'read',
           subject: 'all'
         }
-      ])).toBeInstanceOf(PureAbility)
+      ])).toBeInstanceOf(Ability)
     })
 
     it('provides type validation in `AbilityBuilder`', () => {
@@ -94,7 +94,7 @@ describe(createPrismaAbility.name, () => {
       type Abilities =
         | ['read', Subjects<{ User: User }>]
         | ['read' | 'update', Subjects<{ Post: Post }>]
-      type ThisAbility = PureAbility<Abilities, PrismaQuery>
+      type ThisAbility = Ability<Abilities, PrismaQuery>
       const ability = createPrismaAbility<ThisAbility>()
 
       ability.can('update', 'Post')

--- a/packages/casl-prisma/src/accessibleBy.ts
+++ b/packages/casl-prisma/src/accessibleBy.ts
@@ -1,41 +1,44 @@
-import { AnyAbility, ExtractSubjectType, Generics, PureAbility } from '@casl/ability';
-import { rulesToQuery } from '@casl/ability/extra';
+import { Ability, Generics, Normalize, ExtractSubjectType } from '@casl/ability';
+import { rulesToCondition } from '@casl/ability/extra';
 import { BasePrismaQuery, InferPrismaTypes } from './types';
 
-function convertToPrismaQuery(rule: AnyAbility['rules'][number]) {
+function convertToPrismaQuery(rule: Ability<any, BasePrismaQuery>['rules'][number]) {
   return rule.inverted ? { NOT: rule.conditions } : rule.conditions;
 }
 
-export class AccessibleRecords<TAbility extends PureAbility<any, BasePrismaQuery>> {
+const PRISMA_QUERY_AGGREGATION = {
+  and: (conditions: unknown[]) => ({ AND: conditions }),
+  or: (conditions: unknown[]) => ({ OR: conditions }),
+  empty: () => ({})
+};
+
+type ModelName<TAbility extends Ability<any, BasePrismaQuery>> = Extract<
+  keyof InferPrismaTypes<Generics<TAbility>['conditions']>['WhereInput'],
+  string
+>;
+type SubjectType<TAbility extends Ability<any, BasePrismaQuery>> = Extract<
+  ExtractSubjectType<Normalize<Generics<TAbility>['abilities']>[1]>,
+  ModelName<TAbility>
+>;
+
+export class AccessibleRecords<TAbility extends Ability<any, BasePrismaQuery>> {
   constructor(
     private readonly _ability: TAbility,
     private readonly _action: string
   ) {}
 
-  ofType<TSubjectType extends ExtractSubjectType<Parameters<TAbility['rulesFor']>[1]> & string>(
+  ofType<TSubjectType extends SubjectType<TAbility>>(
     subjectType: TSubjectType
   ): InferPrismaTypes<Generics<TAbility>['conditions']>['WhereInput'][TSubjectType] {
-    const query = rulesToQuery(this._ability, this._action, subjectType, convertToPrismaQuery);
+    const rules = this._ability.rulesFor(this._action, subjectType);
+    const query = rulesToCondition(rules, convertToPrismaQuery, PRISMA_QUERY_AGGREGATION);
+    const finalQuery = query === null ? { OR: [] } : query;
 
-    if (query === null) {
-      return { OR: [] } as any;
-    }
-
-    const prismaQuery = Object.create(null);
-
-    if (query.$or) {
-      prismaQuery.OR = query.$or;
-    }
-
-    if (query.$and) {
-      prismaQuery.AND = query.$and;
-    }
-
-    return prismaQuery;
+    return finalQuery as InferPrismaTypes<Generics<TAbility>['conditions']>['WhereInput'][TSubjectType];
   }
 }
 
-export function accessibleBy<TAbility extends PureAbility<any, BasePrismaQuery>>(
+export function accessibleBy<TAbility extends Ability<any, BasePrismaQuery>>(
   ability: TAbility,
   action: TAbility["rules"][number]["action"] & string = "read"
 ): AccessibleRecords<TAbility> {

--- a/packages/casl-prisma/src/createPrismaAbility.ts
+++ b/packages/casl-prisma/src/createPrismaAbility.ts
@@ -1,17 +1,17 @@
 import {
-  AbilityOptions,
-  AbilityOptionsOf,
-  AbilityTuple,
+  type AbilityOptions,
+  type AbilityOptionsOf,
+  type AbilityTuple,
   fieldPatternMatcher,
-  PureAbility,
-  RawRuleFrom,
-  RawRuleOf
+  Ability,
+  type RawRuleFrom,
+  type RawRuleOf
 } from '@casl/ability';
 import { prismaQuery } from './prisma/prismaQuery';
-import { BasePrismaQuery } from './types';
+import type { BasePrismaQuery } from './types';
 
 export function createPrismaAbility<
-  T extends PureAbility<any, BasePrismaQuery>
+  T extends Ability<any, BasePrismaQuery>
 >(rules?: RawRuleOf<T>[], options?: AbilityOptionsOf<T>): T;
 export function createPrismaAbility<
   A extends AbilityTuple = [string, string],
@@ -19,9 +19,9 @@ export function createPrismaAbility<
 >(
   rules?: RawRuleFrom<A, C>[],
   options?: AbilityOptions<A, C>
-): PureAbility<A, C>;
-export function createPrismaAbility(rules: any[] = [], options = {}): PureAbility<any, any> {
-  return new PureAbility(rules, {
+): Ability<A, C>;
+export function createPrismaAbility(rules: any[] = [], options = {}): Ability<any, any> {
+  return new Ability(rules, {
     ...options,
     conditionsMatcher: prismaQuery,
     fieldMatcher: fieldPatternMatcher,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -157,8 +157,8 @@ importers:
         version: 3.1.0
     devDependencies:
       '@casl/ability':
-        specifier: ^6.0.0
-        version: 6.8.1
+        specifier: workspace:*
+        version: link:../casl-ability
       '@casl/dx':
         specifier: workspace:^1.0.0
         version: link:../dx


### PR DESCRIPTION
BREAKING CHANGE: migrates to @casl/ability 7.x, `PureAbility` is no longer available and `accessibleBy` produces a different shape