### PR TITLE
fix: ensure rules index cache is not polluted with not defined actions

### DIFF
--- a/packages/casl-ability/spec/ability.spec.ts
+++ b/packages/casl-ability/spec/ability.spec.ts
@@ -808,6 +808,16 @@ describe('Ability', () => {
       ])
     })
 
+    it('does not include actions from `possibleRulesFor` cache misses', () => {
+      const ability = defineAbility(can => can('read', 'Post'))
+
+      ability.possibleRulesFor('archive', 'Post')
+
+      expect(ability.actionsFor('Post')).toEqual([
+        'read',
+      ])
+    })
+
     it('returns an empty array if there are no actions for provided subject type and no actions for "all" subject type', () => {
       const ability = createMongoAbility()
 

--- a/packages/casl-ability/spec/pack_rules.spec.ts
+++ b/packages/casl-ability/spec/pack_rules.spec.ts
@@ -1,3 +1,4 @@
+import { createMongoAbility } from '../src'
 import { packRules, unpackRules } from '../src/extra'
 
 describe('Ability rules packing', () => {
@@ -83,6 +84,18 @@ describe('Ability rules packing', () => {
 
       expect(rules[0][5]).toBe(reason)
       expect(rules[0]).toHaveLength(6)
+    })
+
+    it('packs rules passed from Ability rulesFor method', () => {
+      const ability = createMongoAbility([
+        { action: 'read', subject: 'Post' },
+        { action: 'delete', subject: 'Post' }
+      ])
+      const rules = packRules(ability.rulesFor('read', 'Post'))
+
+      expect(rules).toEqual([
+        ['read', 'Post'],
+      ])
     })
   })
 

--- a/packages/casl-ability/src/RuleIndex.ts
+++ b/packages/casl-ability/src/RuleIndex.ts
@@ -136,6 +136,7 @@ export class RuleIndex<A extends Abilities, Conditions> {
     } as unknown as UpdateEvent<this>;
 
     this._emit('update', event);
+    this._hasPerFieldRules = false;
     this._rules = rules;
     this._indexAndAnalyzeRules(rules);
     this._emit('updated', event);
@@ -176,43 +177,49 @@ export class RuleIndex<A extends Abilities, Conditions> {
     }
   }
 
-  possibleRulesFor(...args: AbilitySubjectTypeParameters<A, false>): Rule<A, Conditions>[];
+  possibleRulesFor(...args: AbilitySubjectTypeParameters<A, false>): readonly Rule<A, Conditions>[];
   possibleRulesFor(
     action: string,
     subjectType: SubjectType = this._anySubjectType
-  ): Rule<A, Conditions>[] {
+  ): readonly Rule<A, Conditions>[] {
     if (!isSubjectType(subjectType)) {
       throw new Error('"possibleRulesFor" accepts only subject types (i.e., string or class) as the 2nd parameter');
     }
 
-    const subjectRules = getOrDefault(this._indexedRules, subjectType, defaultSubjectEntry);
-    const actionRules = getOrDefault(subjectRules, action, defaultActionEntry);
+    const subjectRules = this._indexedRules.get(subjectType);
+    const actionRules = subjectRules?.get(action);
 
-    if (actionRules.merged) {
+    if (actionRules?.merged) {
       return actionRules.rules;
     }
 
-    const anyActionRules = action !== this._anyAction && subjectRules.has(this._anyAction)
-      ? subjectRules.get(this._anyAction)!.rules
+    const anyActionRules = action !== this._anyAction && !!subjectRules?.has(this._anyAction)
+      ? Object.freeze(subjectRules.get(this._anyAction)!.rules)
       : undefined;
-    let rules = mergePrioritized(actionRules.rules, anyActionRules);
+    let rules = mergePrioritized(actionRules?.rules, anyActionRules);
 
     if (subjectType !== this._anySubjectType) {
       rules = mergePrioritized(rules, (this as any).possibleRulesFor(action, this._anySubjectType));
     }
 
-    actionRules.rules = rules;
-    actionRules.merged = true;
+    if (actionRules) {
+      actionRules.rules = Object.freeze(rules) as Rule<A, Conditions>[];
+      actionRules.merged = true;
+    }
 
     return rules;
   }
 
-  rulesFor(...args: AbilitySubjectTypeParameters<A>): Rule<A, Conditions>[];
-  rulesFor(action: string, subjectType?: SubjectType, field?: string): Rule<A, Conditions>[] {
+  rulesFor(...args: AbilitySubjectTypeParameters<A>): readonly Rule<A, Conditions>[];
+  rulesFor(
+    action: string,
+    subjectType?: SubjectType,
+    field?: string
+  ): readonly Rule<A, Conditions>[] {
     const rules: Rule<A, Conditions>[] = (this as any).possibleRulesFor(action, subjectType);
 
     if (field && typeof field !== 'string') {
-      throw new Error('The 3rd, `field` parameter is expected to be a string. See https://stalniy.github.io/casl/en/api/casl-ability#can-of-pure-ability for details');
+      throw new Error('The 3rd, `field` parameter is expected to be a string. See https://casl.js.org/v6/en/api/casl-ability#can-of-ability for details');
     }
 
     if (!this._hasPerFieldRules) {

--- a/packages/casl-ability/src/extra/packRules.ts
+++ b/packages/casl-ability/src/extra/packRules.ts
@@ -15,7 +15,7 @@ export type PackRule<T extends RawRule<any, any>> =
 export type PackSubjectType<T extends SubjectType> = (type: T) => string;
 
 export function packRules<T extends RawRule<any, any>>(
-  rules: T[],
+  rules: readonly T[],
   packSubject?: PackSubjectType<T['subject']>
 ): PackRule<T>[] {
   return rules.map((rule) => {

--- a/packages/casl-ability/src/extra/rulesToCondition.ts
+++ b/packages/casl-ability/src/extra/rulesToCondition.ts
@@ -47,7 +47,7 @@ export function rulesToAST<T extends AnyAbility>(
  * @param hooks - The logical combination hooks for the target format.
  */
 export function rulesToCondition<T extends AnyAbility, R, Result>(
-  rules: RuleOf<T>[],
+  rules: readonly RuleOf<T>[],
   convert: (rule: RuleOf<T>) => R,
   hooks: {
     and: (conditions: R[]) => Result,

--- a/packages/casl-ability/src/utils.ts
+++ b/packages/casl-ability/src/utils.ts
@@ -128,16 +128,16 @@ export function createAliasResolver(aliasMap: AliasesMap, options?: AliasResolve
   return (action: string | string[]) => expandActions(aliasMap, action, defaultAliasMerge);
 }
 
-function copyArrayTo<T>(dest: T[], target: T[], start: number) {
+function copyArrayTo<T>(dest: T[], target: readonly T[], start: number) {
   for (let i = start; i < target.length; i++) {
     dest.push(target[i]);
   }
 }
 
 export function mergePrioritized<T extends { priority: number }>(
-  array?: T[],
-  anotherArray?: T[]
-): T[] {
+  array?: readonly T[],
+  anotherArray?: readonly T[]
+): readonly T[] {
   if (!array || !array.length) {
     return anotherArray || [];
   }


### PR DESCRIPTION
## Why

`.possibleRulesFor` polluted cache when was called with an action which was not defined in rules.

## What

1. fixes cache pollution
2. returns readonly array from `possibleRulesFor`. This is a breaking change on types level

**BREAKING CHANGE**: `.possibleRulesFor` and `.rulesFor` return `readonly Rule[]`