### PR TITLE
fix(ability): support classes with protected/private constructors in AnyClass type

### DIFF
--- a/packages/casl-ability/src/AbilityBuilder.ts
+++ b/packages/casl-ability/src/AbilityBuilder.ts
@@ -108,7 +108,7 @@ export class AbilityBuilder<T extends AnyAbility> {
     ) => this._addRule(action, subject, conditionsOrFields, conditions, true);
 
     this.build = options => (isAbilityClass(this._createAbility)
-      ? new this._createAbility(this.rules, options)
+      ? new (this._createAbility as new (...args: any[]) => T)(this.rules, options)
       : this._createAbility(this.rules, options));
   }
 

--- a/packages/casl-ability/src/types.ts
+++ b/packages/casl-ability/src/types.ts
@@ -2,7 +2,7 @@ import type { Condition } from '@ucast/mongo2js';
 import { Container, GenericFactory } from './hkt';
 
 type Fn = (...args: any[]) => any;
-export type AnyClass<ReturnType = any> = new (...args: any[]) => ReturnType;
+export type AnyClass<ReturnType = any> = abstract new (...args: any[]) => ReturnType;
 type AnyRecord = Record<PropertyKey, any>;
 
 export type AnyObject = Record<PropertyKey, unknown>;


### PR DESCRIPTION
## Description

Changes `AnyClass` type from `new (...args: any[]) => T` to `abstract new (...args: any[]) => T` so that classes with protected or private constructors are correctly recognized as class types.

## Background

Classes with protected/private constructors cannot be used with `new` from outside, which meant they didn't match the `new (...args: any[]) => T` constraint in `AnyClass`. This caused `InferSubjects` and other type-level checks to silently fail for such classes.

The `abstract` modifier on the construct signature makes TypeScript accept both concrete classes and classes that cannot be directly instantiated (protected/private constructors, abstract classes).

## Changes

- `types.ts`: `AnyClass` uses `abstract new` instead of `new`
- `AbilityBuilder.ts`: Added type assertion to concrete construct signature where runtime check guarantees instantiation

## Related Issue

Closes #995

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>